### PR TITLE
fix: bug where did:mailto with pct-encoded email parts was not decoded correctly

### DIFF
--- a/packages/access-api/src/utils/did-mailto.js
+++ b/packages/access-api/src/utils/did-mailto.js
@@ -8,5 +8,5 @@ export function toEmail(did) {
   if (parts[1] !== 'mailto') {
     throw new Error(`DID ${did} is not a mailto did.`)
   }
-  return `${parts[3]}@${parts[2]}`
+  return `${decodeURIComponent(parts[3])}@${decodeURIComponent(parts[2])}`
 }

--- a/packages/access-api/test/access-client-agent.test.js
+++ b/packages/access-api/test/access-client-agent.test.js
@@ -37,7 +37,7 @@ for (const accessApiVariant of /** @type {const} */ ([
       }
       const spaceWithStorageProvider = principal.ed25519.generate()
       async function createContext() {
-        /** @type {{url:string}[]} */
+        /** @type {{url:string,to:string}[]} */
         const emails = []
         const email = createEmail(emails)
         const ctx = await context({
@@ -384,7 +384,7 @@ for (const accessApiVariant of /** @type {const} */ ([
     const abort = new AbortController()
     after(() => abort.abort())
     const account = {
-      email: /** @type {const} */ ('example@dag.house'),
+      email: /** @type {const} */ ('example+123@dag.house'),
       did: thisEmailDidMailto,
     }
     const { connection, emails } = await accessApiVariant.create()
@@ -409,6 +409,9 @@ for (const accessApiVariant of /** @type {const} */ ([
       with: space.did,
     })
     assertNotError(spaceInfoResult)
+
+    const latestEmail = emails.at(-1)
+    assert.deepEqual(latestEmail?.to, account.email, 'emails are equal')
   })
 
   it('authorizeWithPollClaim', async () => {


### PR DESCRIPTION
… right, causing access/authorize not to send emails for email addresses with '+'

Motivation:
* https://github.com/web3-storage/w3cli/issues/73