### PR TITLE
fix: toucan-js in access-api does not use RewriteFrame integration

### DIFF
--- a/packages/access-api/package.json
+++ b/packages/access-api/package.json
@@ -19,7 +19,6 @@
   "license": "(Apache-2.0 OR MIT)",
   "dependencies": {
     "@ipld/dag-ucan": "^3.2.0",
-    "@sentry/integrations": "^7.28.0",
     "@ucanto/core": "^5.2.0",
     "@ucanto/interface": "^6.2.0",
     "@ucanto/principal": "^5.1.0",

--- a/packages/access-api/src/utils/context.js
+++ b/packages/access-api/src/utils/context.js
@@ -15,7 +15,6 @@ import {
 } from '../models/delegations.js'
 import { createD1Database } from './d1.js'
 import { DbProvisions } from '../models/provisions.js'
-import { RewriteFrames } from '@sentry/integrations'
 
 /**
  * Obtains a route context object.
@@ -48,7 +47,6 @@ export function getContext(request, env, ctx) {
   const sentry = new Toucan({
     context: ctx,
     integrations: [
-      new RewriteFrames({ root: '/' }),
       new RequestData({
         allowedHeaders: ['user-agent', 'x-client'],
         allowedSearchParams: /(.*)/,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,6 @@ importers:
       '@miniflare/core': ^2.11.0
       '@miniflare/r2': ^2.12.1
       '@sentry/cli': 2.7.0
-      '@sentry/integrations': ^7.28.0
       '@types/assert': ^1.5.6
       '@types/git-rev-sync': ^2.0.0
       '@types/mocha': ^10.0.1
@@ -77,7 +76,6 @@ importers:
       wrangler: ^2.13.0
     dependencies:
       '@ipld/dag-ucan': 3.2.0
-      '@sentry/integrations': 7.28.0
       '@ucanto/core': 5.2.0
       '@ucanto/interface': 6.2.0
       '@ucanto/principal': 5.1.0
@@ -3228,32 +3226,9 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@sentry/integrations/7.28.0:
-    resolution: {integrity: sha512-OS51DRs1lvI/pQaxcpsxOxhbDKB3ZxTZglVjoCr7pZQm7pb6gzQF2oaYT+W1hMgK0h/mEgyR9XWDOAZCa2aMBg==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@sentry/types': 7.28.0
-      '@sentry/utils': 7.28.0
-      localforage: 1.10.0
-      tslib: 1.14.1
-    dev: false
-
-  /@sentry/types/7.28.0:
-    resolution: {integrity: sha512-F6tZldpvC3Lt8FPgJ6wRTcE7P9txIpHSBjyYz9wqFlVJx4IhBmrn6vZU1LvANUaK1jZZF2PW5tFRrVEnydfpqg==}
-    engines: {node: '>=8'}
-    dev: false
-
   /@sentry/types/7.28.1:
     resolution: {integrity: sha512-DvSplMVrVEmOzR2M161V5+B8Up3vR71xMqJOpWTzE9TqtFJRGPtqT/5OBsNJJw1+/j2ssMcnKwbEo9Q2EGeS6g==}
     engines: {node: '>=8'}
-    dev: false
-
-  /@sentry/utils/7.28.0:
-    resolution: {integrity: sha512-ag1RotlFSJnwUi/MYWY5iQ8aLcwrCBlD/qlGB43PvB3XGDl3e7E/pUy2bdblP7Q2uCKLVUBcudyaSgtvNqu9wA==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@sentry/types': 7.28.0
-      tslib: 1.14.1
     dev: false
 
   /@sentry/utils/7.28.1:
@@ -8383,10 +8358,6 @@ packages:
       queue: 6.0.2
     dev: true
 
-  /immediate/3.0.6:
-    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
-    dev: false
-
   /immer/9.0.19:
     resolution: {integrity: sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==}
     dev: true
@@ -9253,12 +9224,6 @@ packages:
       type-check: 0.4.0
     dev: true
 
-  /lie/3.1.1:
-    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
-    dependencies:
-      immediate: 3.0.6
-    dev: false
-
   /lilconfig/2.0.6:
     resolution: {integrity: sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==}
     engines: {node: '>=10'}
@@ -9395,12 +9360,6 @@ packages:
     resolution: {integrity: sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==}
     engines: {node: '>= 12.13.0'}
     dev: true
-
-  /localforage/1.10.0:
-    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
-    dependencies:
-      lie: 3.1.1
-    dev: false
 
   /locate-path/3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/w3up/issues/623#issuecomment-1499833258
  * this was suggested by toucan-js author as no longer being needed in 3.0.0. 