### PR TITLE
fix: access-api cli.js build does sourcemap=external instead of true

### DIFF
--- a/packages/access-api/scripts/cli.js
+++ b/packages/access-api/scripts/cli.js
@@ -67,7 +67,7 @@ prog
           global: 'globalThis',
         },
         minify: opts.env !== 'dev',
-        sourcemap: true,
+        sourcemap: 'external',
         jsxImportSource: 'preact',
         jsx: 'automatic',
         loader: { '.js': 'jsx' },


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/w3up/issues/623#issuecomment-1499808790