### PR TITLE
fix: add POSTMARK_TOKEN back to list of required env

### DIFF
--- a/packages/access-api/src/config.js
+++ b/packages/access-api/src/config.js
@@ -15,7 +15,7 @@ export function loadConfig(env) {
   const vars = {}
 
   /** @type {Array<keyof env>} */
-  const required = ['DID', 'ENV', 'DEBUG', 'PRIVATE_KEY']
+  const required = ['DID', 'ENV', 'DEBUG', 'PRIVATE_KEY', 'POSTMARK_TOKEN']
 
   for (const name of required) {
     const val = env[name]


### PR DESCRIPTION
The service is not fully operational without this environment variable - it's unable to send emails to authorize users and so is unusable for anyone who does not already have an existing auth session.

I think it was a mistake to remove this - if it was intentional, then we also need to update the reference to `vars.POSTMARK_TOKEN` below to refer to `env.POSTMARK_TOKEN`.