### PR TITLE
fix: account for edge cases in polling abort

### DIFF
--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -117,7 +117,7 @@ export async function pollAccessClaimUntil(
   const interval = opts?.interval || 250
   const claimed = await new Promise((resolve, reject) => {
     opts?.signal?.addEventListener('abort', (e) => {
-      reject(new Error('pollAccessClaimUntil aborted', { cause: e }))
+      reject(new Error('access/claim polling aborted', { cause: e }))
     })
     poll(interval)
     /**
@@ -125,7 +125,7 @@ export async function pollAccessClaimUntil(
      */
     async function poll(retryAfter) {
       if (opts?.signal?.aborted) {
-        reject(new Error('pollAccessClaimUntil aborted'))
+        reject(new Error('access/claim polling aborted'))
       } else {
         const pollClaimResult = await access.invokeAndExecute(
           w3caps.Access.claim,

--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -117,9 +117,7 @@ export async function pollAccessClaimUntil(
   const interval = opts?.interval || 250
   const claimed = await new Promise((resolve, reject) => {
     opts?.signal?.addEventListener('abort', (e) => {
-      reject(
-        new Error('pollAccessClaimUntil aborted', { cause: e })
-      )
+      reject(new Error('pollAccessClaimUntil aborted', { cause: e }))
     })
     poll(interval)
     /**

--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -116,12 +116,17 @@ export async function pollAccessClaimUntil(
 ) {
   const interval = opts?.interval || 250
   while (true) {
-    if (opts?.signal?.aborted) throw opts.signal.reason ?? new Error('operation aborted')
-    const res = await access.invokeAndExecute(w3caps.Access.claim, { with: delegee })
+    if (opts?.signal?.aborted)
+      throw opts.signal.reason ?? new Error('operation aborted')
+    const res = await access.invokeAndExecute(w3caps.Access.claim, {
+      with: delegee,
+    })
     if (res.error) throw res
-    const claims = Object.values(res.delegations).flatMap(d => bytesToDelegations(d))
+    const claims = Object.values(res.delegations).flatMap((d) =>
+      bytesToDelegations(d)
+    )
     if (delegationsMatch(claims)) return claims
-    await new Promise(resolve => setTimeout(resolve, interval))
+    await new Promise((resolve) => setTimeout(resolve, interval))
   }
 }
 

--- a/packages/access-client/test/agent-use-cases.test.js
+++ b/packages/access-client/test/agent-use-cases.test.js
@@ -152,4 +152,39 @@ describe('authorizeWaitAndClaim', async function () {
     assert(authorizeHandler.calledOnce)
     assert(claimHandler.calledOnce)
   })
+
+  it('should not poll if the signal is aborted', async function () {
+    const authorizeHandler = sinon.fake.resolves({})
+    const claimHandler = sinon.stub()
+
+    const server = createServer({
+      access: {
+        authorize: Server.provide(Access.authorize, authorizeHandler),
+        claim: Server.provide(Access.claim, claimHandler),
+      },
+    })
+    const agent = await Agent.create(undefined, {
+      connection: connection({ principal: server.id, channel: server }),
+    })
+    claimHandler.onFirstCall().resolves({ delegations: {} })
+    const controller = new AbortController()
+    controller.abort()
+    const pollingInterval = 250
+    await assert.rejects(
+      authorizeWaitAndClaim(agent, 'foo@example.com', {
+        signal: controller.signal,
+        expectAuthorization: (access, opts) =>
+          waitForAuthorizationByPolling(access, {
+            ...opts,
+            interval: pollingInterval,
+          }),
+      })
+    )
+    // wait for 2 polling intervals to let any remaining polling finish
+    await new Promise((resolve) =>
+      setTimeout(() => resolve(true), pollingInterval * 2)
+    )
+    assert(authorizeHandler.calledOnce)
+    assert(claimHandler.notCalled)
+  })
 })


### PR DESCRIPTION
My previous implementation (https://github.com/web3-storage/w3up/pull/756) relied on canceling a timeout to stop the polling process. This had a number of edge cases, including one where the signal was aborted before first round of polling happened, which is quite common since we do some network calls before we even get to this code.

Stop worrying about canceling the timeout since we'll just stop polling whenever we execute `poll` in this new implementation - generally this relies on a piece of "persistent" state (in the sense that `signal.aborted` will continue to be true) rather than the assumption that the correct timeout will get canceled, so is quite a bit more robust.