### PR TITLE
fix: adjust shard size

### DIFF
--- a/packages/upload-client/src/sharding.js
+++ b/packages/upload-client/src/sharding.js
@@ -2,7 +2,7 @@ import Queue from 'p-queue'
 import { encode } from './car.js'
 import { add } from './store.js'
 
-const SHARD_SIZE = 1024 * 1024 * 100
+const SHARD_SIZE = 1024 * 1024 * 120
 const CONCURRENT_UPLOADS = 3
 
 /**


### PR DESCRIPTION
As discussed with @ribasushi, this is a better shard size to set to avoid excessive null padding in the aggregated piece.