### PR TITLE
fix: docs for `uploadCAR` return value

### DIFF
--- a/packages/upload-client/README.md
+++ b/packages/upload-client/README.md
@@ -222,8 +222,9 @@ function uploadCAR(
     onShardStored?: ShardStoredCallback
     shardSize?: number
     concurrentRequests?: number
+    rootCID?: CID
   } = {}
-): Promise<void>
+): Promise<CID>
 ```
 
 Uploads a CAR file to the service. The difference between this function and [Store.add](#storeadd) is that the CAR file is automatically sharded and an "upload" is registered (see [`Upload.add`](#uploadadd)), linking the individual shards. Use the `onShardStored` callback to obtain the CIDs of the CAR file shards.

--- a/packages/w3up-client/README.md
+++ b/packages/w3up-client/README.md
@@ -326,7 +326,7 @@ function uploadCAR (
     concurrentRequests?: number
     rootCID?: CID
   } = {}
-): Promise<void>
+): Promise<CID>
 ```
 
 Uploads a CAR file to the service. The difference between this function and [capability.store.add](#capabilitystoreadd) is that the CAR file is automatically sharded and an "upload" is registered (see [`capability.upload.add`](#capabilityuploadadd)), linking the individual shards. Use the `onShardStored` callback to obtain the CIDs of the CAR file shards.


### PR DESCRIPTION
`uploadCAR` actually returns the root CID, which is either the root CID in the CAR header, the passed `rootCID` option value or the CID of the last block in the CAR.