### PR TITLE
feat: enable reuse of stored invocations for delegations storage

### DIFF
--- a/packages/upload-api/src/access/confirm.js
+++ b/packages/upload-api/src/access/confirm.js
@@ -73,7 +73,7 @@ export async function confirm({ capability, invocation }, ctx) {
   // Store the delegations so that they can be pulled with access/claim
   // The fact that we're storing proofs chains that we pulled from the
   // database is not great, but it's a tradeoff we're making for now.
-  await ctx.delegationsStorage.putMany(delegation, attestation)
+  await ctx.delegationsStorage.putMany(invocation.asCID, delegation, attestation)
 
   return {
     ok: {

--- a/packages/upload-api/src/access/confirm.js
+++ b/packages/upload-api/src/access/confirm.js
@@ -73,7 +73,7 @@ export async function confirm({ capability, invocation }, ctx) {
   // Store the delegations so that they can be pulled with access/claim
   // The fact that we're storing proofs chains that we pulled from the
   // database is not great, but it's a tradeoff we're making for now.
-  await ctx.delegationsStorage.putMany(invocation.asCID, delegation, attestation)
+  await ctx.delegationsStorage.putMany(invocation.link(), [delegation, attestation])
 
   return {
     ok: {

--- a/packages/upload-api/src/access/delegate.js
+++ b/packages/upload-api/src/access/delegate.js
@@ -35,7 +35,7 @@ export const delegate = async ({ capability, invocation }, context) => {
   )
 
   if (result.ok) {
-    await context.delegationsStorage.putMany(...delegated.ok)
+    await context.delegationsStorage.putMany(invocation.asCID, ...delegated.ok)
     return { ok: {} }
   } else {
     return result

--- a/packages/upload-api/src/access/delegate.js
+++ b/packages/upload-api/src/access/delegate.js
@@ -35,7 +35,7 @@ export const delegate = async ({ capability, invocation }, context) => {
   )
 
   if (result.ok) {
-    await context.delegationsStorage.putMany(invocation.asCID, ...delegated.ok)
+    await context.delegationsStorage.putMany(invocation.link(), delegated.ok)
     return { ok: {} }
   } else {
     return result

--- a/packages/upload-api/src/types/delegations.ts
+++ b/packages/upload-api/src/types/delegations.ts
@@ -14,6 +14,7 @@ export interface DelegationsStorage<
    * @param delegations - delegations to store
    */
   putMany: (
+    cause: Ucanto.Link,
     ...delegations: Array<Ucanto.Delegation<Ucanto.Tuple<Cap>>>
   ) => Promise<Ucanto.Result<{}, never>>
 

--- a/packages/upload-api/src/types/delegations.ts
+++ b/packages/upload-api/src/types/delegations.ts
@@ -15,7 +15,7 @@ export interface DelegationsStorage<
    */
   putMany: (
     cause: Ucanto.Link,
-    ...delegations: Array<Ucanto.Delegation<Ucanto.Tuple<Cap>>>
+    delegations: Ucanto.Delegation<Ucanto.Tuple<Cap>>[]
   ) => Promise<Ucanto.Result<{}, never>>
 
   /**

--- a/packages/upload-api/test/delegations-storage-tests.js
+++ b/packages/upload-api/test/delegations-storage-tests.js
@@ -46,7 +46,7 @@ export function testVariant(createVariant, test) {
     const delegations = await Promise.all(
       Array.from({ length: count }).map(() => createSampleDelegation())
     )
-    await delegationsStorage.putMany(delegations[0].asCID, ...delegations)
+    await delegationsStorage.putMany(delegations[0].asCID, delegations)
     assert.deepEqual(await delegationsStorage.count(), delegations.length)
   })
   test('can retrieve delegations by audience', async (/**@type {unknown} */ context) => {
@@ -76,7 +76,7 @@ export function testVariant(createVariant, test) {
       )
     )
 
-    await delegations.putMany(delegationsForAlice[0].asCID, ...delegationsForAlice, ...delegationsForBob)
+    await delegations.putMany(delegationsForAlice[0].link(), [...delegationsForAlice, ...delegationsForBob])
 
     const aliceDelegations = (await delegations.find({ audience: alice.did() })).ok
     assert.deepEqual(aliceDelegations?.length, delegationsForAlice.length)

--- a/packages/upload-api/test/delegations-storage-tests.js
+++ b/packages/upload-api/test/delegations-storage-tests.js
@@ -46,7 +46,7 @@ export function testVariant(createVariant, test) {
     const delegations = await Promise.all(
       Array.from({ length: count }).map(() => createSampleDelegation())
     )
-    await delegationsStorage.putMany(...delegations)
+    await delegationsStorage.putMany(delegations[0].asCID, ...delegations)
     assert.deepEqual(await delegationsStorage.count(), delegations.length)
   })
   test('can retrieve delegations by audience', async (/**@type {unknown} */ context) => {
@@ -76,7 +76,7 @@ export function testVariant(createVariant, test) {
       )
     )
 
-    await delegations.putMany(...delegationsForAlice, ...delegationsForBob)
+    await delegations.putMany(delegationsForAlice[0].asCID, ...delegationsForAlice, ...delegationsForBob)
 
     const aliceDelegations = (await delegations.find({ audience: alice.did() })).ok
     assert.deepEqual(aliceDelegations?.length, delegationsForAlice.length)

--- a/packages/upload-api/test/delegations-storage.js
+++ b/packages/upload-api/test/delegations-storage.js
@@ -17,7 +17,7 @@ export class DelegationsStorage {
    * @param  {Array<Types.Delegation<Types.Tuple<any>>>} delegations
    * @returns
    */
-  async putMany(_, ...delegations) {
+  async putMany(_, delegations) {
     this.delegations = [...delegations, ...this.delegations]
     return { ok: {} }
   }

--- a/packages/upload-api/test/delegations-storage.js
+++ b/packages/upload-api/test/delegations-storage.js
@@ -13,10 +13,11 @@ export class DelegationsStorage {
 
   /**
    *
+   * @param {Types.Link} _
    * @param  {Array<Types.Delegation<Types.Tuple<any>>>} delegations
    * @returns
    */
-  async putMany(...delegations) {
+  async putMany(_, ...delegations) {
     this.delegations = [...delegations, ...this.delegations]
     return { ok: {} }
   }


### PR DESCRIPTION
we'd like to stop storing copies of delegations separately, and to do that we need to pass the CID of the invocation where the delegations do live so that we can grab it and pull delegations out of it when they are requested. This interface change enables this change, which is implemented in w3infra in https://github.com/web3-storage/w3infra/pull/201