### PR TITLE
feat: tweak `DelegationsStorage#putMany` to make `cause` optional

### DIFF
--- a/packages/upload-api/src/access/confirm.js
+++ b/packages/upload-api/src/access/confirm.js
@@ -70,10 +70,12 @@ export async function confirm({ capability, invocation }, ctx) {
     expiration: Infinity,
   })
 
-  // Store the delegations so that they can be pulled with access/claim
-  // The fact that we're storing proofs chains that we pulled from the
-  // database is not great, but it's a tradeoff we're making for now.
-  await ctx.delegationsStorage.putMany(invocation.link(), [delegation, attestation])
+  // Store the delegations so that they can be pulled with access/claim.
+  // Since there is no invocation that contains these delegations, don't pass
+  // a `cause` parameter.
+  // TODO: we should invoke access/delegate here rather than interacting with
+  // the delegations storage system directly.
+  await ctx.delegationsStorage.putMany([delegation, attestation])
 
   return {
     ok: {

--- a/packages/upload-api/src/access/delegate.js
+++ b/packages/upload-api/src/access/delegate.js
@@ -35,7 +35,7 @@ export const delegate = async ({ capability, invocation }, context) => {
   )
 
   if (result.ok) {
-    await context.delegationsStorage.putMany(invocation.link(), delegated.ok)
+    await context.delegationsStorage.putMany(delegated.ok, { cause: invocation.link() })
     return { ok: {} }
   } else {
     return result

--- a/packages/upload-api/src/types/delegations.ts
+++ b/packages/upload-api/src/types/delegations.ts
@@ -9,13 +9,16 @@ export interface DelegationsStorage<
   Cap extends Ucanto.Capability = Ucanto.Capability
 > {
   /**
-   * write several items into storage
-   *
-   * @param delegations - delegations to store
+   * Write several items into storage.
+   * 
+   * Options accept an optional `cause` that MUST be the CID of the invocation
+   * that contains the given delegation. Implementations MAY choose
+   * to avoid storing delegations as long as they can reliably
+   * retrieve the invocation by CID when they need to return the given delegations.
    */
   putMany: (
-    cause: Ucanto.Link,
-    delegations: Ucanto.Delegation<Ucanto.Tuple<Cap>>[]
+    delegations: Ucanto.Delegation<Ucanto.Tuple<Cap>>[],
+    options?: { cause?: Ucanto.Link }
   ) => Promise<Ucanto.Result<{}, never>>
 
   /**

--- a/packages/upload-api/src/types/delegations.ts
+++ b/packages/upload-api/src/types/delegations.ts
@@ -11,8 +11,8 @@ export interface DelegationsStorage<
   /**
    * Write several items into storage.
    * 
-   * Options accept an optional `cause` that MUST be the CID of the invocation
-   * that contains the given delegation. Implementations MAY choose
+   * Options accepts an optional `cause` that MUST be the CID of the invocation
+   * that contains the given delegations. Implementations MAY choose
    * to avoid storing delegations as long as they can reliably
    * retrieve the invocation by CID when they need to return the given delegations.
    */

--- a/packages/upload-api/test/delegations-storage-tests.js
+++ b/packages/upload-api/test/delegations-storage-tests.js
@@ -39,7 +39,7 @@ export const test = {
     const delegations = await Promise.all(
       Array.from({ length: count }).map(() => createSampleDelegation())
     )
-    await delegationsStorage.putMany(delegations[0].asCID, delegations)
+    await delegationsStorage.putMany(delegations)
     assert.deepEqual(await delegationsStorage.count(), BigInt(delegations.length))
   },
   'can retrieve delegations by audience': async (assert, context) => {
@@ -69,7 +69,7 @@ export const test = {
       )
     )
 
-    await delegations.putMany(delegationsForAlice[0].link(), [...delegationsForAlice, ...delegationsForBob])
+    await delegations.putMany([...delegationsForAlice, ...delegationsForBob])
 
     const aliceDelegations = (await delegations.find({ audience: alice.did() })).ok
     assert.deepEqual(aliceDelegations?.length, delegationsForAlice.length)

--- a/packages/upload-api/test/delegations-storage.js
+++ b/packages/upload-api/test/delegations-storage.js
@@ -12,12 +12,9 @@ export class DelegationsStorage {
   }
 
   /**
-   *
-   * @param {Types.Link} _
    * @param  {Array<Types.Delegation<Types.Tuple<any>>>} delegations
-   * @returns
    */
-  async putMany(_, delegations) {
+  async putMany(delegations) {
     this.delegations = [...delegations, ...this.delegations]
     return { ok: {} }
   }


### PR DESCRIPTION
Move the `cause` parameter of `putMany` into an options hash and make clear that it is an optional parameter intended to allow some storage implementations to not store delegations themselves but instead rely on CID-identified UCAN invocations that they already have access to.