### PR TITLE
fix: run build before trying to build docs!

### DIFF
--- a/.github/workflows/reusable-deploy-docs.yml
+++ b/.github/workflows/reusable-deploy-docs.yml
@@ -23,6 +23,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - run: pnpm install
+      - run: pnpm build
       - run: pnpm run lint
       - run: pnpm run docs
       - uses: actions/configure-pages@v2


### PR DESCRIPTION
we got errors deploying docs for the new capabilities package: https://github.com/web3-storage/w3up/actions/runs/5205442170/jobs/9390901212#step:6:56 - I think this should fix