### PR TITLE
feat: add failure type to DelegationsStorage#putMany return

### DIFF
--- a/packages/upload-api/src/types/delegations.ts
+++ b/packages/upload-api/src/types/delegations.ts
@@ -19,7 +19,7 @@ export interface DelegationsStorage<
   putMany: (
     delegations: Ucanto.Delegation<Ucanto.Tuple<Cap>>[],
     options?: { cause?: Ucanto.Link }
-  ) => Promise<Ucanto.Result<{}, never>>
+  ) => Promise<Ucanto.Result<{}, Ucanto.Failure>>
 
   /**
    * get number of stored items


### PR DESCRIPTION
it's possible for this to fail, so types should reflect that