### PR TITLE
fix: bump package number to ensure w3up-client depends on >= access@15

### DIFF
--- a/packages/w3up-client/package.json
+++ b/packages/w3up-client/package.json
@@ -79,7 +79,7 @@
     "@ucanto/interface": "^8.0.0",
     "@ucanto/principal": "^8.0.0",
     "@ucanto/transport": "^8.0.0",
-    "@web3-storage/access": "workspace:^",
+    "@web3-storage/access": "workspace:^15",
     "@web3-storage/capabilities": "workspace:^",
     "@web3-storage/upload-client": "workspace:^"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -508,7 +508,7 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       '@web3-storage/access':
-        specifier: workspace:^
+        specifier: workspace:^15
         version: link:../access-client
       '@web3-storage/capabilities':
         specifier: workspace:^


### PR DESCRIPTION
I released these packages in the wrong order, so the new w3up-client still depends on v14, which points at access.web3.storage. tweak the version dep (in a way I'll revert later) to ensure we move past that.