### PR TITLE
fix: support for Node.js 20

### DIFF
--- a/.github/workflows/access-client.yml
+++ b/.github/workflows/access-client.yml
@@ -18,6 +18,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version:
+          - 18
+          - 20
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2.2.3
@@ -25,7 +30,7 @@ jobs:
           version: 8
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm run build

--- a/.github/workflows/aggregate-client.yml
+++ b/.github/workflows/aggregate-client.yml
@@ -18,6 +18,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version:
+          - 18
+          - 20
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2.2.3
@@ -25,7 +30,7 @@ jobs:
           version: 8
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm run build

--- a/.github/workflows/upload-client.yml
+++ b/.github/workflows/upload-client.yml
@@ -18,6 +18,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version:
+          - 18
+          - 20
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2.2.3
@@ -25,7 +30,7 @@ jobs:
           version: 8
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm run build

--- a/.github/workflows/w3up-client.yml
+++ b/.github/workflows/w3up-client.yml
@@ -16,6 +16,11 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version:
+          - 18
+          - 20
     defaults:
       run:
         working-directory: ./packages/w3up-client
@@ -29,7 +34,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ matrix.node_version }}
           registry-url: https://registry.npmjs.org/
           cache: 'pnpm'
       - run: pnpm --filter '@web3-storage/w3up-client...' install

--- a/packages/upload-client/src/car.js
+++ b/packages/upload-client/src/car.js
@@ -55,7 +55,7 @@ export class BlockStream extends ReadableStream {
       blocksPromise = CarBlockIterator.fromIterable(toIterable(car.stream()))
       return blocksPromise
     }
-    
+
     /** @type {AsyncIterator<Block>?} */
     let iterator = null
     super({

--- a/packages/upload-client/src/car.js
+++ b/packages/upload-client/src/car.js
@@ -42,10 +42,20 @@ export class BlockStream extends ReadableStream {
     let blocksPromise = null
     const getBlocksIterable = () => {
       if (blocksPromise) return blocksPromise
+      // FIXME: remove when resolved: https://github.com/nodejs/node/issues/48916
+      /* c8 ignore next 10 */
+      if (parseInt(globalThis.process?.versions?.node) > 18) {
+        blocksPromise = (async () => {
+          // @ts-expect-error
+          const bytes = await car.arrayBuffer()
+          return CarBlockIterator.fromBytes(new Uint8Array(bytes))
+        })()
+        return blocksPromise
+      }
       blocksPromise = CarBlockIterator.fromIterable(toIterable(car.stream()))
       return blocksPromise
     }
-
+    
     /** @type {AsyncIterator<Block>?} */
     let iterator = null
     super({
@@ -77,11 +87,11 @@ export class BlockStream extends ReadableStream {
  * @param {{ getReader: () => ReadableStreamDefaultReader<T> } | AsyncIterable<T>} stream
  * @returns {AsyncIterable<T>}
  */
+/* c8 ignore next 16 */
 function toIterable(stream) {
   return Symbol.asyncIterator in stream
     ? stream
-    : /* c8 ignore next 12 */
-      (async function* () {
+    : (async function* () {
         const reader = stream.getReader()
         try {
           while (true) {


### PR DESCRIPTION
Support Node.js 20 in the clients.

Adds a temporary fix for Node.js 20 as `blob.stream()` is currently broken: https://github.com/nodejs/node/issues/48916

Also adds matrix config to CI workflows so that tests are run in both node 18 & 20.