### PR TITLE
feat: add providers to space/info

### DIFF
--- a/packages/upload-api/src/space.js
+++ b/packages/upload-api/src/space.js
@@ -6,7 +6,7 @@ import * as API from './types.js'
 /**
  * @param {API.Input<Space.info>} input
  * @param {API.SpaceServiceContext} ctx
- * @returns {Promise<API.Result<{ did: API.SpaceDID }, API.Failure>>}
+ * @returns {Promise<API.Result<API.SpaceInfoSuccess, API.SpaceInfoFailure>>}
  */
 export const info = async ({ capability }, ctx) => {
   const { provisionsStorage: provisions } = ctx
@@ -23,10 +23,14 @@ export const info = async ({ capability }, ctx) => {
     }
   }
 
-  const result = await provisions.hasStorageProvider(spaceDid)
-  if (result.ok) {
+  const result = await provisions.getStorageProviders(spaceDid)
+  const providers = result.ok
+  if (providers && (providers.length > 0)) {
     return {
-      ok: { did: spaceDid },
+      ok: {
+        did: spaceDid,
+        providers
+      },
     }
   }
 

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -92,6 +92,7 @@ import {
   ProviderAddSuccess,
   ProviderAddFailure,
   SpaceInfo,
+  ProviderDID,
 } from '@web3-storage/capabilities/types'
 import * as Capabilities from '@web3-storage/capabilities'
 
@@ -173,7 +174,7 @@ export interface Service {
     add: ServiceMethod<ProviderAdd, ProviderAddSuccess, ProviderAddFailure>
   }
   space: {
-    info: ServiceMethod<SpaceInfo, SpaceInfoResult, Failure | SpaceUnknown>
+    info: ServiceMethod<SpaceInfo, SpaceInfoSuccess, SpaceInfoFailure>
   }
 }
 
@@ -331,9 +332,11 @@ export interface UploadTable {
   ) => Promise<ListResponse<UploadListItem>>
 }
 
-export type SpaceInfoResult = {
+export type SpaceInfoSuccess = {
   did: SpaceDID
+  providers: ProviderDID[]
 }
+export type SpaceInfoFailure = Failure | SpaceUnknown
 
 export interface UnknownProvider extends Failure {
   name: 'UnknownProvider'

--- a/packages/upload-api/src/types/provisions.ts
+++ b/packages/upload-api/src/types/provisions.ts
@@ -37,8 +37,11 @@ export interface Subscription {
 export interface ProvisionsStorage<ProviderDID = Ucanto.DID<'web'>> {
   services: ProviderDID[]
   hasStorageProvider: (
-    consumer: Ucanto.DID<'key'>
+    consumer: Ucanto.DIDKey
   ) => Promise<Ucanto.Result<boolean, never>>
+  getStorageProviders: (
+    consumer: Ucanto.DIDKey
+  ) => Promise<Ucanto.Result<ProviderDID[], never>>
   /**
    * ensure item is stored
    *

--- a/packages/upload-api/test/provisions-storage.js
+++ b/packages/upload-api/test/provisions-storage.js
@@ -34,11 +34,30 @@ export class ProvisionsStorage {
    *
    * @param {Types.DIDKey} consumer
    */
-  async hasStorageProvider(consumer) {
+  async getStorageProviders(consumer) {
     return {
-      ok: !!Object.values(this.provisions).find((i) => i.consumer === consumer),
+      ok: Array.from(
+        Object.values(this.provisions)
+          .reduce((m, p) => {
+            if (p.consumer === consumer) {
+              m.add(p.provider)
+            }
+            return m
+          }, new Set())
+      )
     }
   }
+
+  /**
+ *
+ * @param {Types.DIDKey} consumer
+ */
+  async hasStorageProvider(consumer) {
+    return {
+      ok: (await this.getStorageProviders(consumer)).ok.length > 0
+    }
+  }
+
 
   /**
    *
@@ -79,11 +98,11 @@ export class ProvisionsStorage {
     return exists
       ? { ok: { did: customer } }
       : {
-          error: {
-            name: 'CustomerNotFound',
-            message: 'customer does not exist',
-          },
-        }
+        error: {
+          name: 'CustomerNotFound',
+          message: 'customer does not exist',
+        },
+      }
   }
 
   /**

--- a/packages/upload-api/test/space-info.spec.js
+++ b/packages/upload-api/test/space-info.spec.js
@@ -68,11 +68,8 @@ describe('space/info', function () {
     if (inv.out.error) {
       assert.fail(inv.out.error.message)
     } else {
-      assert.ok(
-        isSubset(inv.out.ok, {
-          did: space.did(),
-        })
-      )
+      assert.equal(inv.out.ok.did, space.did())
+      assert.deepEqual(inv.out.ok.providers, [service.did()])
     }
   })
 


### PR DESCRIPTION
I believe we currently don't have any way for an agent to figure out which providers a space is registered to - add a list of providers to `space/info` to enable this in the CLI and w3console