### PR TITLE
feat: add subscriptions to CustomerGetSuccess

### DIFF
--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -85,6 +85,7 @@ export interface InvalidProvider extends Ucanto.Failure {
 export type CustomerGet = InferInvokedCapability<typeof CustomerCaps.get>
 export interface CustomerGetSuccess {
   did: AccountDID
+  subscriptions: string[]
 }
 export interface CustomerNotFound extends Ucanto.Failure {
   name: 'CustomerNotFound'

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -114,7 +114,7 @@ export type SubscriptionGet = InferInvokedCapability<
 >
 export interface SubscriptionGetSuccess {
   customer: AccountDID
-  consumer: DIDKey
+  consumer?: DIDKey
 }
 export interface SubscriptionNotFound extends Ucanto.Failure {
   name: 'SubscriptionNotFound'

--- a/packages/upload-api/src/customer/get.js
+++ b/packages/upload-api/src/customer/get.js
@@ -24,11 +24,10 @@ const get = async ({ capability }, context) => {
     return { error: new UnknownProvider(capability.with) }
   }
 
-  const result = await context.provisionsStorage.getCustomer(
+  return await context.provisionsStorage.getCustomer(
     capability.with,
     capability.nb.customer
   )
-  return result.ok ? { ok: { did: result.ok.did } } : result
 }
 
 class UnknownProvider extends Provider.Failure {

--- a/packages/upload-api/src/types/provisions.ts
+++ b/packages/upload-api/src/types/provisions.ts
@@ -29,7 +29,7 @@ export interface Customer {
 
 export interface Subscription {
   customer: AccountDID
-  consumer: Ucanto.DIDKey
+  consumer?: Ucanto.DIDKey
 }
 
 /**

--- a/packages/upload-api/src/types/provisions.ts
+++ b/packages/upload-api/src/types/provisions.ts
@@ -24,6 +24,7 @@ export interface Consumer {
 
 export interface Customer {
   did: Ucanto.DID<'mailto'>
+  subscriptions: string[]
 }
 
 export interface Subscription {

--- a/packages/upload-api/test/provisions-storage-tests.js
+++ b/packages/upload-api/test/provisions-storage-tests.js
@@ -77,7 +77,10 @@ export const test = {
     // verify that provisions are returned as part of customer record
     const customerResult = await storage.getCustomer(provider, issuer.did())
     assert.ok(!customerResult.error, 'error getting customer record')
-    assert.deepEqual(customerResult.ok, { did: issuer.did() })
+    assert.deepEqual(customerResult.ok, {
+      did: issuer.did(),
+      subscriptions: []
+    })
 
     const fakeCustomerResult = await storage.getCustomer(
       provider,

--- a/packages/upload-api/test/provisions-storage-tests.js
+++ b/packages/upload-api/test/provisions-storage-tests.js
@@ -12,7 +12,8 @@ export const test = {
     const spaceA = await principal.ed25519.generate()
     const spaceB = await principal.ed25519.generate()
     const issuerKey = await principal.ed25519.generate()
-    const issuer = issuerKey.withDID('did:mailto:example.com:foo')
+    const issuerDID = 'did:mailto:example.com:foo'
+    const issuer = issuerKey.withDID(issuerDID)
     const provider = 'did:web:web3.storage:providers:w3up-alpha'
     const invocation = await Provider.add
       .invoke({
@@ -79,7 +80,7 @@ export const test = {
     assert.ok(!customerResult.error, 'error getting customer record')
     assert.deepEqual(customerResult.ok, {
       did: issuer.did(),
-      subscriptions: []
+      subscriptions: [`${issuerDID}@${provider}`]
     })
 
     const fakeCustomerResult = await storage.getCustomer(

--- a/packages/upload-api/test/provisions-storage.js
+++ b/packages/upload-api/test/provisions-storage.js
@@ -73,17 +73,25 @@ export class ProvisionsStorage {
    * @returns
    */
   async getCustomer(provider, customer) {
-    const exists = Object.values(this.provisions).find(
+    const provisions = Object.values(this.provisions).filter(
       (p) => p.provider === provider && p.customer === customer
     )
-    return exists
-      ? { ok: { did: customer } }
-      : {
-          error: {
-            name: 'CustomerNotFound',
-            message: 'customer does not exist',
-          },
+    const exists = provisions.length > 0
+    if (exists) {
+      return {
+        ok: {
+          did: customer,
+          subscriptions: provisions.map(itemKey)
         }
+      }
+    } else {
+      return {
+        error: {
+          name: 'CustomerNotFound',
+          message: 'customer does not exist',
+        },
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
this is needed by w3admin to be able to navigate from a customer to their subscriptions (ie, to see the spaces they've registered)