### PR TITLE
fix: add a test that exercises ProvisionsStorage#getConsumer

### DIFF
--- a/packages/upload-api/test/provisions-storage-tests.js
+++ b/packages/upload-api/test/provisions-storage-tests.js
@@ -44,6 +44,10 @@ export const test = {
       spaceA.did()
     )
     assert.deepEqual(spaceHasStorageProvider?.ok, true)
+
+    const consumer = await storage.getConsumer(provider, spaceA.did())
+    assert.equal(result.ok?.id, consumer.ok?.subscription)
+    
     // ensure no error if we try to store same provision twice
     const dupeResult = await storage.put(provision)
     assert.ok(
@@ -80,7 +84,7 @@ export const test = {
     assert.ok(!customerResult.error, 'error getting customer record')
     assert.deepEqual(customerResult.ok, {
       did: issuer.did(),
-      subscriptions: [/** @type {string} */ (result.ok?.id)]
+      subscriptions: [/** @type {string} */ (result.ok?.id)],
     })
 
     const fakeCustomerResult = await storage.getCustomer(

--- a/packages/upload-api/test/provisions-storage.js
+++ b/packages/upload-api/test/provisions-storage.js
@@ -152,7 +152,7 @@ export class ProvisionsStorage {
           did: provision.consumer,
           allocated: 0,
           limit: 100,
-          subscription: provision.customer,
+          subscription: itemKey(provision),
         },
       }
     } else {


### PR DESCRIPTION
this was not tested previously, which lead to staging failures in w3infra