### PR TITLE
fix: types for capability specific clients

### DIFF
--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -15,6 +15,8 @@ import { UploadClient } from './capability/upload.js'
 import { SpaceClient } from './capability/space.js'
 import { AccessClient } from './capability/access.js'
 
+export { StoreClient, UploadClient, SpaceClient, AccessClient }
+
 export class Client extends Base {
   /**
    * @param {import('@web3-storage/access').AgentData} agentData

--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -343,4 +343,19 @@ describe('Client', () => {
       assert.equal(alice.defaultProvider(), 'did:web:web3.storage')
     })
   })
+
+  describe('capability', () => {
+    it('should allow typed access to capability specific clients', async () => {
+      const client = new Client(await AgentData.create())
+      assert.equal(typeof client.capability.access.authorize, 'function')
+      assert.equal(typeof client.capability.access.claim, 'function')
+      assert.equal(typeof client.capability.space.info, 'function')
+      assert.equal(typeof client.capability.store.add, 'function')
+      assert.equal(typeof client.capability.store.list, 'function')
+      assert.equal(typeof client.capability.store.remove, 'function')
+      assert.equal(typeof client.capability.upload.add, 'function')
+      assert.equal(typeof client.capability.upload.list, 'function')
+      assert.equal(typeof client.capability.upload.remove, 'function')
+    })
+  })
 })


### PR DESCRIPTION
<img width="500" alt="Screenshot 2023-09-06 at 12 17 57" src="https://github.com/web3-storage/w3up/assets/152863/4c95952b-aa31-4653-9ec5-c0cb5730f850">

These classes were not exported and so typescript was unable to determine the type.