### PR TITLE
fix: store add should validate size right away

### DIFF
--- a/packages/upload-api/src/store/add.js
+++ b/packages/upload-api/src/store/add.js
@@ -13,11 +13,9 @@ export function storeAddProvider(context) {
     const { link, origin, size } = capability.nb
 
     if (size > maxUploadSize) {
-      // checking this last, as larger CAR may already exist in bucket from pinning service fetch.
-      // we only want to prevent this here so we don't give the user a PUT url they can't use.
       return {
         error: new Server.Failure(
-          `Size must not exceed ${maxUploadSize}. Split CAR into smaller shards`
+          `Maximum size exceeded: ${maxUploadSize}, split DAG into smaller shards.`
         ),
       }
     }

--- a/packages/upload-api/src/store/add.js
+++ b/packages/upload-api/src/store/add.js
@@ -11,6 +11,17 @@ export function storeAddProvider(context) {
   const { storeTable, carStoreBucket, maxUploadSize } = context
   return Server.provide(Store.add, async ({ capability, invocation }) => {
     const { link, origin, size } = capability.nb
+
+    if (size > maxUploadSize) {
+      // checking this last, as larger CAR may already exist in bucket from pinning service fetch.
+      // we only want to prevent this here so we don't give the user a PUT url they can't use.
+      return {
+        error: new Server.Failure(
+          `Size must not exceed ${maxUploadSize}. Split CAR into smaller shards`
+        ),
+      }
+    }
+
     const space = /** @type {import('@ucanto/interface').DIDKey} */ (
       Server.DID.parse(capability.with).did()
     )
@@ -51,16 +62,6 @@ export function storeAddProvider(context) {
           with: space,
           link,
         },
-      }
-    }
-
-    if (size > maxUploadSize) {
-      // checking this last, as larger CAR may already exist in bucket from pinning service fetch.
-      // we only want to prevent this here so we don't give the user a PUT url they can't use.
-      return {
-        error: new Server.Failure(
-          `Size must not exceed ${maxUploadSize}. Split CAR into smaller shards`
-        ),
       }
     }
 

--- a/packages/upload-api/test/store.js
+++ b/packages/upload-api/test/store.js
@@ -349,7 +349,7 @@ export const test = {
 
     assert.ok(storeAdd.out.error)
     assert.equal(
-      storeAdd.out.error?.message.startsWith('Size must not exceed'),
+      storeAdd.out.error?.message.startsWith('Maximum size exceeded:'),
       true
     )
   },


### PR DESCRIPTION
`store/add` enforcing max single put size in context of w3filecoin https://github.com/web3-storage/w3up/issues/827

At this moment, we only fail to provide the presigned URL for upload if size is bigger, but we perform our DB insertions. storeTable insert, and more recently the allocation

- The reasoning for this is described in code: `checking this last, as larger CAR may already exist in bucket from pinning service fetch. we only want to prevent this here so we don't give the user a PUT url they can't use.`
- That makes sense to me from billing perspective. However, we will allocate way more bytes to the space than realistically happens, as well as show this in space store list. 
- Regarding Pinning Service, we should consider chunking into smaller CARs if that is realistic. Perhaps when copying from validation bucket to destination
- 
I think that we should move up the code path this validation