### PR TITLE
fix: a couple URLs in the README

### DIFF
--- a/packages/upload-client/README.md
+++ b/packages/upload-client/README.md
@@ -466,8 +466,9 @@ More information: [`CARMetadata`](#carmetadata)
 
 ## Contributing
 
-Feel free to join in. All welcome. Please [open an issue](https://github.com/web3-storage/w3protocol/issues)!
+Feel free to join in. All welcome. Please [open an issue](https://github.com/web3-storage/w3up/issues)!
 
 ## License
 
-Dual-licensed under [MIT + Apache 2.0](https://github.com/web3-storage/w3protocol/blob/main/license.md)
+Dual-licensed under [MIT + Apache 2.0](https://github.com/web3-storage/w3up/blob/main/license.md)
+


### PR DESCRIPTION
making this a "fix" to bump the `upload-client` version and hopefully unstick the `upload-api` release process: https://github.com/web3-storage/w3up/actions/runs/6425748870/job/17449345888