### PR TITLE
feat: Add basic README to upload-api

### DIFF
--- a/packages/upload-api/README.md
+++ b/packages/upload-api/README.md
@@ -3,7 +3,7 @@
 
 ## About
 
-The `@web3-storage/upload-client` package provides an implementation of the w3up
+The `@web3-storage/upload-api` package provides an implementation of the w3up
 UCAN invocation service. It provides a set of storage interfaces that can
 be implemented to run w3up on top of arbitrary data stores.
 

--- a/packages/upload-api/README.md
+++ b/packages/upload-api/README.md
@@ -1,0 +1,29 @@
+<h1 align="center">⁂<br/>web3.storage</h1>
+<p align="center">The upload API for <a href="https://web3.storage">https://web3.storage</a></p>
+
+## About
+
+The `@web3-storage/upload-client` package provides an implementation of the w3up
+UCAN invocation service. It provides a set of storage interfaces that can
+be implemented to run w3up on top of arbitrary data stores.
+
+## Install
+
+Install the package using npm:
+
+```bash
+npm install @web3-storage/upload-api
+```
+
+## Usage
+
+Coming soon!
+
+## Contributing
+
+Feel free to join in. All welcome. Please [open an issue](https://github.com/web3-storage/w3up/issues)!
+
+## License
+
+Dual-licensed under [MIT + Apache 2.0](https://github.com/web3-storage/w3up/blob/main/license.md)
+


### PR DESCRIPTION
Doing this primarily to bump versions since the last release failed:

https://github.com/web3-storage/w3up/actions/runs/6425748870/job/17449345888