### PR TITLE
feat: revocation handler

### DIFF
--- a/packages/capabilities/src/console.js
+++ b/packages/capabilities/src/console.js
@@ -1,6 +1,12 @@
 import { capability, Schema } from '@ucanto/validator'
 import { equalWith } from './utils.js'
 
+export const console = capability({
+  can: 'console/*',
+  with: Schema.did(),
+  derives: equalWith,
+})
+
 /**
  * Capability that succeeds with the `nb.value` value.
  */

--- a/packages/capabilities/src/index.js
+++ b/packages/capabilities/src/index.js
@@ -12,6 +12,7 @@ import * as RateLimit from './rate-limit.js'
 import * as Admin from './admin.js'
 import * as Subscription from './subscription.js'
 import * as Filecoin from './filecoin.js'
+import * as UCAN from './ucan.js'
 
 export {
   Access,
@@ -28,6 +29,7 @@ export {
   Subscription,
   Filecoin,
   Admin,
+  UCAN,
 }
 
 /** @type {import('./types.js').AbilitiesArray} */

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -15,6 +15,8 @@ import * as SubscriptionCaps from './subscription.js'
 import * as RateLimitCaps from './rate-limit.js'
 import * as FilecoinCaps from './filecoin.js'
 import * as AdminCaps from './admin.js'
+import * as UCANCaps from './ucan.js'
+import exp from 'constants'
 
 export type { Unit, PieceLink }
 
@@ -213,6 +215,39 @@ export type Store = InferInvokedCapability<typeof store>
 export type StoreAdd = InferInvokedCapability<typeof add>
 export type StoreRemove = InferInvokedCapability<typeof remove>
 export type StoreList = InferInvokedCapability<typeof list>
+// UCAN core events
+
+export type UCANRevoke = InferInvokedCapability<typeof UCANCaps.revoke>
+
+/**
+ * Error is raised when `UCAN` been revoked is not supplied or it's proof chain
+ * leading to supplied `scope` is not supplied.
+ */
+export interface UCANNotFound extends Ucanto.Failure {
+  name: 'UCANNotFound'
+}
+
+/**
+ * Error is raised when `UCAN` been revoked does not have provided `scope` in
+ * the proof chain.
+ */
+export interface InvalidRevocationScope extends Ucanto.Failure {
+  name: 'InvalidRevocationScope'
+}
+
+/**
+ * Error is raised when `UCAN` revocation is issued by unauthorized principal,
+ * that is `with` field is not an `iss` of the `scope`.
+ */
+export interface UnauthorizedRevocation extends Ucanto.Failure {
+  name: 'UnauthorizedRevocation'
+}
+
+export type UCANRevokeFailure =
+  | UCANNotFound
+  | InvalidRevocationScope
+  | UnauthorizedRevocation
+
 // Admin
 export type Admin = InferInvokedCapability<typeof AdminCaps.admin>
 export type AdminUploadInspect = InferInvokedCapability<

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -219,7 +219,7 @@ export type StoreList = InferInvokedCapability<typeof list>
 export type UCANRevoke = InferInvokedCapability<typeof UCANCaps.revoke>
 
 /**
- * Error is raised when `UCAN` been revoked is not supplied or it's proof chain
+ * Error is raised when `UCAN` being revoked is not supplied or it's proof chain
  * leading to supplied `scope` is not supplied.
  */
 export interface UCANNotFound extends Ucanto.Failure {
@@ -227,7 +227,7 @@ export interface UCANNotFound extends Ucanto.Failure {
 }
 
 /**
- * Error is raised when `UCAN` been revoked does not have provided `scope` in
+ * Error is raised when `UCAN` being revoked does not have provided `scope` in
  * the proof chain.
  */
 export interface InvalidRevocationScope extends Ucanto.Failure {

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -16,7 +16,6 @@ import * as RateLimitCaps from './rate-limit.js'
 import * as FilecoinCaps from './filecoin.js'
 import * as AdminCaps from './admin.js'
 import * as UCANCaps from './ucan.js'
-import exp from 'constants'
 
 export type { Unit, PieceLink }
 

--- a/packages/capabilities/src/ucan.js
+++ b/packages/capabilities/src/ucan.js
@@ -28,7 +28,7 @@ export const ucan = capability({
  * members.
  *
  * Capability can be used to revoke `nb.ucan` authorization from all proofs
- * chains that lead to the UCAN issued or been delegated to the principal
+ * chains that lead to the UCAN issued or being delegated to the principal
  * identified by the `with` field. Note that revoked UCAN MUST continue to
  * be valid in the invocation where proof chain does not lead to the principal
  * identified by the `with` field.
@@ -41,22 +41,22 @@ export const revoke = capability({
   with: Schema.did(),
   nb: Schema.struct({
     /**
-     * UCAN been revoked from all proof chains that lead to the UCAN that is
-     * either issued (iss) or been delegated to (aud) the principal identified
+     * UCAN being revoked from all proof chains that lead to the UCAN that is
+     * either issued (iss) by or delegated to (aud) the principal identified
      * by the `with` field.
      */
     ucan: UCANLink,
     /**
-     * Proof chain illustrating path from revoked UCAN to the one that is
-     * either issued (iss) or been delegated to (aud) the principal identified
+     * Proof chain illustrating the path from revoked UCAN to the one that is
+     * either issued (iss) by or delegated to (aud) the principal identified
      * by the `with` field.
      *
-     * If UCAN been revoked is either issued (iss) or been delegated to (aud)
+     * If the UCAN being revoked is either issued (iss) by or delegated to (aud)
      * the principal identified by the `with` field no `proof` is required and
      * it can be omitted or set to an empty array.
      *
      * It is RECOMMENDED that `proof` is provided in all other cases otherwise
-     * it MAY not be possible to verify that revoking principal is participant
+     * it MAY not be possible to verify that revoking principal is a participant
      * in the proof chain.
      */
     proof: UCANLink.array().optional(),

--- a/packages/capabilities/src/ucan.js
+++ b/packages/capabilities/src/ucan.js
@@ -3,11 +3,12 @@
  */
 
 import { capability, Schema } from '@ucanto/validator'
-import { equalWith, checkLink, and } from './utils.js'
+import * as API from '@ucanto/interface'
+import { equalWith, equal, and, checkLink } from './utils.js'
 
-export const UCANLink = Schema.link({
-  version: 1,
-})
+export const UCANLink =
+  /** @type {Schema.Schema<API.UCANLink, unknown>} */
+  (Schema.link({ version: 1 }))
 
 /**
  * Capability can only be delegated (but not invoked) allowing audience to
@@ -25,28 +26,50 @@ export const ucan = capability({
  * [UCAN Revocation](https://github.com/ucan-wg/spec#66-revocation) that had
  * been proposed to a UCAN working group and had a tentative support from
  * members.
+ *
+ * Capability can be used to revoke `nb.ucan` authorization from all proofs
+ * chains that lead to the UCAN issued or been delegated to the principal
+ * identified by the `with` field. Note that revoked UCAN MUST continue to
+ * be valid in the invocation where proof chain does not lead to the principal
+ * identified by the `with` field.
  */
 export const revoke = capability({
   can: 'ucan/revoke',
   /**
-   * With MUST be a DID of the UCAN issuer that is in the proof chain of the
-   * delegation been revoked.
+   * DID of the principal authorizing revocation.
    */
   with: Schema.did(),
   nb: Schema.struct({
     /**
-     * Link of the UCAN been revoked, it MUST be a UCAN be either issued by a
-     * principal matching `with` field or depend on the delegation issued by
-     * the principal matching `with` field.
-     *
-     * Alternatively `with` field MAY match the `audience` of the UCAN been revoked,
-     * which would imply that that delegate is revoking capabilities delegated
-     * to it. This allows delegate to prove that it is unable to invoke
-     * delegated capabilities.
+     * UCAN been revoked from all proof chains that lead to the UCAN that is
+     * either issued (iss) or been delegated to (aud) the principal identified
+     * by the `with` field.
      */
-    delegation: UCANLink,
+    ucan: UCANLink,
+    /**
+     * Proof chain illustrating path from revoked UCAN to the one that is
+     * either issued (iss) or been delegated to (aud) the principal identified
+     * by the `with` field.
+     *
+     * If UCAN been revoked is either issued (iss) or been delegated to (aud)
+     * the principal identified by the `with` field no `proof` is required and
+     * it can be omitted or set to an empty array.
+     *
+     * It is RECOMMENDED that `proof` is provided in all other cases otherwise
+     * it MAY not be possible to verify that revoking principal is participant
+     * in the proof chain.
+     */
+    proof: UCANLink.array().optional(),
   }),
   derives: (claim, from) =>
+    // With field MUST be the same
     and(equalWith(claim, from)) ??
-    checkLink(claim.nb.delegation, from.nb.delegation, 'nb.delegation'),
+    // UCAN being revoked MUST be the same
+    and(checkLink(claim.nb.ucan, from.nb.ucan, 'nb.ucan')) ??
+    // And proof chain MUST be the same
+    equal(
+      (claim.nb.proof ?? []).join('/'),
+      (from.nb.proof ?? []).join('/'),
+      'nb.proof'
+    ),
 })

--- a/packages/capabilities/test/capabilities/ucan.test.js
+++ b/packages/capabilities/test/capabilities/ucan.test.js
@@ -19,7 +19,7 @@ describe('ucan/* capabilities', () => {
         audience: service,
         with: alice.did(),
         nb: {
-          delegation,
+          revoke: delegation,
         },
       })
 
@@ -39,7 +39,7 @@ describe('ucan/* capabilities', () => {
         audience: service,
         with: alice.did(),
         nb: {
-          delegation,
+          revoke: delegation,
         },
         proofs: [
           await UCAN.revoke.delegate({
@@ -77,7 +77,7 @@ describe('ucan/* capabilities', () => {
         audience: service,
         with: alice.did(),
         nb: {
-          delegation: proof.cid,
+          revoke: proof.cid,
         },
         proofs: [
           await UCAN.revoke.delegate({
@@ -104,7 +104,7 @@ describe('ucan/* capabilities', () => {
         audience: service,
         with: alice.did(),
         nb: {
-          delegation,
+          revoke: delegation,
         },
         proofs: [
           await UCAN.ucan.delegate({
@@ -131,7 +131,7 @@ describe('ucan/* capabilities', () => {
         audience: service,
         with: mallory.did(),
         nb: {
-          delegation,
+          revoke: delegation,
         },
         proofs: [
           await UCAN.ucan.delegate({
@@ -158,7 +158,7 @@ describe('ucan/* capabilities', () => {
         audience: service,
         with: alice.did(),
         nb: {
-          delegation,
+          revoke: delegation,
         },
         proofs: [
           await UCAN.revoke.delegate({
@@ -166,7 +166,7 @@ describe('ucan/* capabilities', () => {
             with: alice.did(),
             audience: bob,
             nb: {
-              delegation: parseLink('bafkqaaa'),
+              revoke: parseLink('bafkqaaa'),
             },
           }),
         ],

--- a/packages/capabilities/test/capabilities/ucan.test.js
+++ b/packages/capabilities/test/capabilities/ucan.test.js
@@ -19,7 +19,7 @@ describe('ucan/* capabilities', () => {
         audience: service,
         with: alice.did(),
         nb: {
-          revoke: delegation,
+          ucan: delegation,
         },
       })
 
@@ -39,7 +39,7 @@ describe('ucan/* capabilities', () => {
         audience: service,
         with: alice.did(),
         nb: {
-          revoke: delegation,
+          ucan: delegation,
         },
         proofs: [
           await UCAN.revoke.delegate({
@@ -77,7 +77,7 @@ describe('ucan/* capabilities', () => {
         audience: service,
         with: alice.did(),
         nb: {
-          revoke: proof.cid,
+          ucan: proof.cid,
         },
         proofs: [
           await UCAN.revoke.delegate({
@@ -104,7 +104,7 @@ describe('ucan/* capabilities', () => {
         audience: service,
         with: alice.did(),
         nb: {
-          revoke: delegation,
+          ucan: delegation,
         },
         proofs: [
           await UCAN.ucan.delegate({
@@ -131,7 +131,7 @@ describe('ucan/* capabilities', () => {
         audience: service,
         with: mallory.did(),
         nb: {
-          revoke: delegation,
+          ucan: delegation,
         },
         proofs: [
           await UCAN.ucan.delegate({
@@ -158,7 +158,7 @@ describe('ucan/* capabilities', () => {
         audience: service,
         with: alice.did(),
         nb: {
-          revoke: delegation,
+          ucan: delegation,
         },
         proofs: [
           await UCAN.revoke.delegate({
@@ -166,7 +166,7 @@ describe('ucan/* capabilities', () => {
             with: alice.did(),
             audience: bob,
             nb: {
-              revoke: parseLink('bafkqaaa'),
+              ucan: parseLink('bafkqaaa'),
             },
           }),
         ],

--- a/packages/upload-api/src/lib.js
+++ b/packages/upload-api/src/lib.js
@@ -1,9 +1,9 @@
 import * as Server from '@ucanto/server'
-import { Revoked } from '@ucanto/validator'
 import * as Client from '@ucanto/client'
 import * as Types from './types.js'
 import * as Legacy from '@ucanto/transport/legacy'
 import * as CAR from '@ucanto/transport/car'
+import { create as createRevocationChecker } from './utils/revocation.js'
 import { createService as createStoreService } from './store.js'
 import { createService as createUploadService } from './upload.js'
 import { createService as createConsoleService } from './console.js'
@@ -24,86 +24,12 @@ export * from './types.js'
  */
 export const createServer = ({ id, codec = Legacy.inbound, ...context }) =>
   Server.create({
+    ...createRevocationChecker(context),
     id,
     codec,
     service: createService(context),
     catch: (error) => context.errorReporter.catch(error),
-    validateAuthorization: createRevocationChecker(context),
   })
-
-/**
- *
- * @param {Types.RevocationServiceContext} context
- * @returns {Types.UcantoServerContext['validateAuthorization']}
- */
-export const createRevocationChecker =
-  ({ revocationsStorage }) =>
-  async (auth) => {
-    // Compute map of UCANs to principals with revocation authority.
-    const authority = toRevocationAuthority(auth)
-    // Fetch all the revocations for all the UCANs in the authorization chain.
-    const result = await revocationsStorage.query(authority)
-
-    // If query failed we also fail the verification. TODO: Define other error
-    // types because here we do not know if ucan had been revoked or not.
-    if (result.error) {
-      return { error: new Revoked(auth.delegation) }
-    }
-
-    // Now we go through each revocation and check if revocation issuer has
-    // an authority to revoke the UCAN. If so we fail, otherwise we continue.
-    for (const [revoke, scope = {}] of Object.entries(result.ok)) {
-      for (const principal of Object.keys(scope)) {
-        const ucan = (authority[revoke] || {})[
-          /** @type {Types.DID} */ (principal)
-        ]
-        if (ucan) {
-          return { error: new Revoked(ucan) }
-        }
-      }
-    }
-
-    // If no relevant revocation had been found we succeed the verification.
-    return { ok: {} }
-  }
-
-/**
- * Takes an authorization chain and computes mapping between delegation (CID)
- * and principals with revocation authority.
- *
- * @param {Types.Authorization} authorization
- * @param {Record<Types.DID, true>} [scope]
- * @param {Record<string, Record<Types.DID, Types.Delegation>>} [authority]
- * @returns {Record<string, Record<Types.DID, Types.Delegation>>}
- */
-
-const toRevocationAuthority = (
-  { delegation, proofs },
-  // These arguments are used for recursion and are not meant to be provided
-  // by the outside caller.
-  scope = {},
-  authority = {}
-) => {
-  // Add delegation issuer and audience as principals with revocation authority.
-  const delegationScope = {
-    ...scope,
-    [delegation.issuer.did()]: delegation,
-    [delegation.audience.did()]: delegation,
-  }
-
-  // Map delegation to corresponding revocations authorities. Given that we can
-  // not see the same delegation twice in the same delegation chain we not need
-  // to worry about overwriting same entry.
-  authority[delegation.cid.toString()] = delegationScope
-
-  // Recursively compute revocation authorities for each proof and incorporate
-  // them into the final result.
-  for (const proof of proofs) {
-    Object.assign(authority, toRevocationAuthority(proof, delegationScope))
-  }
-
-  return authority
-}
 
 /**
  * @param {Types.ServiceContext} context

--- a/packages/upload-api/src/lib.js
+++ b/packages/upload-api/src/lib.js
@@ -14,6 +14,7 @@ import { createService as createProviderService } from './provider.js'
 import { createService as createSubscriptionService } from './subscription.js'
 import { createService as createAdminService } from './admin.js'
 import { createService as createRateLimitService } from './rate-limit.js'
+import { createService as createUcanService } from './ucan.js'
 
 export * from './types.js'
 
@@ -45,6 +46,7 @@ export const createService = (context) => ({
   store: createStoreService(context),
   subscription: createSubscriptionService(context),
   upload: createUploadService(context),
+  ucan: createUcanService(context),
 })
 
 /**

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -100,6 +100,8 @@ import {
   ProviderAddFailure,
   SpaceInfo,
   ProviderDID,
+  UCANRevoke,
+  UCANRevokeFailure,
 } from '@web3-storage/capabilities/types'
 import * as Capabilities from '@web3-storage/capabilities'
 import { RevocationsStorage } from './types/revocations'
@@ -112,10 +114,7 @@ export type {
   DelegationsStorage,
   Query as DelegationsStorageQuery,
 } from './types/delegations'
-export type {
-  Revocation,
-  RevocationsStorage, 
-} from './types/revocations'
+export type { Revocation, RevocationsStorage } from './types/revocations'
 export type { RateLimitsStorage, RateLimit } from './types/rate-limits'
 
 export interface Service {
@@ -182,6 +181,11 @@ export interface Service {
       RateLimitListFailure
     >
   }
+
+  ucan: {
+    revoke: ServiceMethod<UCANRevoke, Unit, UCANRevokeFailure>
+  }
+
   admin: {
     store: {
       inspect: ServiceMethod<

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -103,11 +103,7 @@ import {
   UCANRevoke,
 } from '@web3-storage/capabilities/types'
 import * as Capabilities from '@web3-storage/capabilities'
-import {
-  RevocationsStorage,
-  RevocationQuery,
-  MatchingRevocations,
-} from './types/revocations'
+import { RevocationsStorage } from './types/revocations'
 
 export * from '@web3-storage/capabilities/types'
 export * from '@ucanto/interface'

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -28,6 +28,13 @@ export type ValidationEmailSend = {
   url: string
 }
 
+export interface Timestamp {
+  /**
+   * Unix timestamp in seconds.
+   */
+  time: number
+}
+
 export type SpaceDID = DIDKey
 export type ServiceDID = DID<'web'>
 export type ServiceSigner = Signer<ServiceDID>
@@ -187,7 +194,7 @@ export interface Service {
   }
 
   ucan: {
-    revoke: ServiceMethod<UCANRevoke, Unit, Failure>
+    revoke: ServiceMethod<UCANRevoke, Timestamp, Failure>
   }
 
   admin: {

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -103,7 +103,11 @@ import {
   UCANRevoke,
 } from '@web3-storage/capabilities/types'
 import * as Capabilities from '@web3-storage/capabilities'
-import { RevocationsStorage } from './types/revocations'
+import {
+  RevocationsStorage,
+  RevocationQuery,
+  MatchingRevocations,
+} from './types/revocations'
 
 export * from '@web3-storage/capabilities/types'
 export * from '@ucanto/interface'
@@ -113,7 +117,12 @@ export type {
   DelegationsStorage,
   Query as DelegationsStorageQuery,
 } from './types/delegations'
-export type { Revocation, RevocationsStorage } from './types/revocations'
+export type {
+  Revocation,
+  RevocationQuery,
+  MatchingRevocations,
+  RevocationsStorage,
+} from './types/revocations'
 export type { RateLimitsStorage, RateLimit } from './types/rate-limits'
 
 export interface Service {

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -101,7 +101,6 @@ import {
   SpaceInfo,
   ProviderDID,
   UCANRevoke,
-  UCANRevokeFailure,
 } from '@web3-storage/capabilities/types'
 import * as Capabilities from '@web3-storage/capabilities'
 import { RevocationsStorage } from './types/revocations'
@@ -183,7 +182,7 @@ export interface Service {
   }
 
   ucan: {
-    revoke: ServiceMethod<UCANRevoke, Unit, UCANRevokeFailure>
+    revoke: ServiceMethod<UCANRevoke, Unit, Failure>
   }
 
   admin: {
@@ -218,7 +217,8 @@ export type StoreServiceContext = SpaceServiceContext & {
 }
 
 export type UploadServiceContext = ConsumerServiceContext &
-  SpaceServiceContext & {
+  SpaceServiceContext &
+  RevocationServiceContext & {
     signer: EdSigner.Signer
     uploadTable: UploadTable
     dudewhereBucket: DudewhereBucket

--- a/packages/upload-api/src/types/revocations.ts
+++ b/packages/upload-api/src/types/revocations.ts
@@ -29,8 +29,9 @@ export interface RevocationsStorage {
    * Creates or updates revocation for given `revoke` by setting `scope` to
    * the one passed in the argument. This is intended to compact revocation
    * store by dropping all existing revocations for given `revoke` in favor of
-   * given one. It supposed to be called when revocation authority is the same
-   * as ucan issue as such revocation will apply to all possible invocations.
+   * given one. It is supposed to be called when the revocation authority is the
+   * same as the UCAN issuer, as such a revocation will apply to all possible
+   * invocations.
    */
   reset: (
     revocation: Revocation

--- a/packages/upload-api/src/types/revocations.ts
+++ b/packages/upload-api/src/types/revocations.ts
@@ -2,8 +2,8 @@ import * as Ucanto from '@ucanto/interface'
 
 export interface Revocation {
   revoke: Ucanto.UCANLink
-  scope: Ucanto.UCANLink
-  cause: Ucanto.UCANLink 
+  scope: Ucanto.DID
+  cause: Ucanto.UCANLink
 }
 
 export interface RevocationsStorage {
@@ -14,16 +14,26 @@ export interface RevocationsStorage {
    */
   getAll: (
     query: Revocation['revoke'][]
-  ) => Promise<
-    Ucanto.Result<Revocation[], Ucanto.Failure>
-  >
+  ) => Promise<Ucanto.Result<Revocation[], Ucanto.Failure>>
 
   /**
-   * Add the given revocations to the revocation store.
+   * Add the given revocations to the revocation store. If there is a revocation
+   * for given `revoke` with a different `scope` revocation with the given scope
+   * will be added. If there is a revocation for given `revoke` and `scope` no
+   * revocation will be added or updated.
    */
-  addAll: (
-    revocations: Revocation[]
-  ) => Promise<
-    Ucanto.Result<Ucanto.Unit, Ucanto.Failure>
-  >
+  add: (
+    revocation: Revocation
+  ) => Promise<Ucanto.Result<Ucanto.Unit, Ucanto.Failure>>
+
+  /**
+   * Creates or updates revocation for given `revoke` by setting `scope` to
+   * the one passed in the argument. This is intended to compact revocation
+   * store by dropping all existing revocations for given `revoke` in favor of
+   * given one. It supposed to be called when revocation authority is the same
+   * as ucan issue as such revocation will apply to all possible invocations.
+   */
+  reset: (
+    revocation: Revocation
+  ) => Promise<Ucanto.Result<Ucanto.Unit, Ucanto.Failure>>
 }

--- a/packages/upload-api/src/types/revocations.ts
+++ b/packages/upload-api/src/types/revocations.ts
@@ -8,13 +8,12 @@ export interface Revocation {
 
 export interface RevocationsStorage {
   /**
-   * Given a list of delegation CIDs, return a Ucanto Result with
-   * any revocations in the store whose `revoke` field matches one of
-   * the given CIDs.
+   * Given a map of delegations (keyed by delegation CID), return a
+   * corresponding map of principals (keyed by DID) that revoked them.
    */
-  getAll: (
-    query: Revocation['revoke'][]
-  ) => Promise<Ucanto.Result<Revocation[], Ucanto.Failure>>
+  query(
+    query: RevocationQuery
+  ): Promise<Ucanto.Result<MatchingRevocations, Ucanto.Failure>>
 
   /**
    * Add the given revocations to the revocation store. If there is a revocation
@@ -37,3 +36,20 @@ export interface RevocationsStorage {
     revocation: Revocation
   ) => Promise<Ucanto.Result<Ucanto.Unit, Ucanto.Failure>>
 }
+
+/**
+ * A map of revocations for which we want to find corresponding
+ * revocations in the store.
+ */
+export type RevocationQuery = Record<
+  Ucanto.ToString<Ucanto.UCANLink>,
+  Ucanto.Unit
+>
+
+/**
+ * Map of ucans to map of principals that issued revocations for them.
+ */
+export type MatchingRevocations = Record<
+  Ucanto.ToString<Ucanto.UCANLink>,
+  Record<Ucanto.DID, Ucanto.Unit>
+>

--- a/packages/upload-api/src/ucan.js
+++ b/packages/upload-api/src/ucan.js
@@ -4,7 +4,7 @@ import * as API from './types.js'
 /**
  * @param {API.UploadServiceContext} context
  */
-export function createService(context) {
+export const createService = (context) => {
   return {
     revoke: ucanRevokeProvider(context),
   }

--- a/packages/upload-api/src/ucan.js
+++ b/packages/upload-api/src/ucan.js
@@ -1,0 +1,11 @@
+import { ucanRevokeProvider } from './ucan/revoke.js'
+import * as API from './types.js'
+
+/**
+ * @param {API.UploadServiceContext} context
+ */
+export function createService(context) {
+  return {
+    revoke: ucanRevokeProvider(context),
+  }
+}

--- a/packages/upload-api/src/ucan/revoke.js
+++ b/packages/upload-api/src/ucan/revoke.js
@@ -34,7 +34,7 @@ export const ucanRevokeProvider = ({ revocationsStorage }) =>
             cause: invocation.cid,
           })
 
-    return result
+    return result.error ? result : { ok: { time: Date.now() } }
   })
 
 /**

--- a/packages/upload-api/src/ucan/revoke.js
+++ b/packages/upload-api/src/ucan/revoke.js
@@ -4,7 +4,7 @@ import * as API from '../types.js'
 
 /**
  * @param {API.RevocationServiceContext} context
- * @returns {API.ServiceMethod<API.UCANRevoke, API.Unit, API.Failure>}
+ * @returns {API.ServiceMethod<API.UCANRevoke, API.Timestamp, API.Failure>}
  */
 export const ucanRevokeProvider = ({ revocationsStorage }) =>
   provide(revoke, async ({ capability, invocation }) => {

--- a/packages/upload-api/src/ucan/revoke.js
+++ b/packages/upload-api/src/ucan/revoke.js
@@ -1,0 +1,154 @@
+import { provide, Delegation, Failure } from '@ucanto/server'
+import { revoke } from '@web3-storage/capabilities/ucan'
+import * as API from '../types.js'
+
+/**
+ * @param {API.UploadServiceContext} context
+ * @returns {API.ServiceMethod<API.UCANRevoke, API.Unit, API.UCANRevokeFailure>}
+ */
+export const ucanRevokeProvider = (context) =>
+  provide(revoke, async ({ capability, invocation }) => {
+    // First attempt to resolve linked UCANS to ensure that proof chain
+    // has been provided.
+    const result = resolve({ capability, blocks: invocation.blocks })
+    if (result.error) {
+      return result
+    }
+    const { ucan, proof, principal } = result.ok
+
+    // If the principal is issuer or audience of the UCAN been revoked then
+    // we can store it as a sole revocation as it will always apply.
+    if (isParticipant(ucan, principal)) {
+      return { ok: {} }
+    }
+    // Otherwise we could verify that the principal authorizing revocation
+    // is a participant in the proof chain, however we do not do that here
+    // since such revocations are not going to apply.
+    else {
+      return { ok: {} }
+    }
+  })
+
+/**
+ *
+ * @param {API.DID} principal
+ * @param {API.Delegation} scope
+ * @returns {API.Result<API.Unit, API.UnauthorizedRevocation>}
+ */
+const validatePrincipal = (principal, scope) => {
+  if (principal !== scope.issuer.did() && principal !== scope.audience.did()) {
+    return {
+      error: new UnauthorizedRevocation({
+        scope,
+        principal,
+      }),
+    }
+  } else {
+    return { ok: {} }
+  }
+}
+
+/**
+ * @param {API.Delegation} ucan
+ * @param {API.DID} principal
+ * @returns
+ */
+const isParticipant = (ucan, principal) =>
+  principal !== ucan.issuer.did() && principal !== ucan.audience.did()
+
+/**
+ * @param {object} input
+ * @param {API.UCANRevoke} input.capability
+ * @param {API.BlockStore<unknown>} input.blocks
+ * @returns {API.Result<{ ucan: API.Delegation, proof: API.Delegation[], principal: API.DID }, API.UCANRevokeFailure>}
+ */
+
+const resolve = ({ capability, blocks }) => {
+  const { nb: input, with: principal } = capability
+  // First we try to load UCANs from the invocation blocks, if they are not
+  // found we can not verify the revocation and therefore we fail.
+  const ucan = Delegation.view({ root: input.ucan, blocks: blocks }, null)
+
+  if (!ucan) {
+    return {
+      error: new UCANNotFound({ ucan: input.ucan, role: 'nb.ucan' }),
+    }
+  }
+
+  const proof = []
+  for (const [at, root] of (input.proof ?? []).entries()) {
+    const ucan = Delegation.view({ root, blocks }, null)
+    if (!ucan) {
+      return {
+        error: new UCANNotFound({ ucan: root, role: `nb.proof[${at}]` }),
+      }
+    } else {
+      proof.push(ucan)
+    }
+  }
+
+  return { ok: { ucan, proof, principal } }
+}
+
+class UCANNotFound extends Failure {
+  /**
+   * @param {object} input
+   * @param {API.UCANLink} input.ucan
+   * @param {string} input.role
+   */
+  constructor({ ucan, role }) {
+    super()
+    this.ucan = ucan
+    this.role = role
+  }
+  get name() {
+    return /** @type {const} */ ('UCANNotFound')
+  }
+  describe() {
+    return `The ${this.role} UCAN ${this.ucan} is not found, it MUST be included with the revocation.`
+  }
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      stack: this.stack,
+      ucan: { '/': this.ucan.toString() },
+    }
+  }
+}
+
+class UnauthorizedRevocation extends Failure {
+  /**
+   * @param {object} input
+   *
+   * @param {API.DID} input.principal
+   * @param {API.Delegation} input.scope
+   */
+  constructor({ principal, scope }) {
+    super()
+    this.principal = principal
+    this.scope = scope
+  }
+  get name() {
+    return /** @type {const} */ ('UnauthorizedRevocation')
+  }
+  describe() {
+    return `The principal ${this.principal} is not authorized to revoke in the scope ${this.scope.cid} where it is neither issuer ${this.issuer} nor audience ${this.audience}.`
+  }
+  get issuer() {
+    return this.scope.issuer.did()
+  }
+  get audience() {
+    return this.scope.audience.did()
+  }
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      stack: this.stack,
+      issuer: this.issuer,
+      audience: this.audience,
+      scope: { '/': this.scope.cid.toString() },
+    }
+  }
+}

--- a/packages/upload-api/src/ucan/revoke.js
+++ b/packages/upload-api/src/ucan/revoke.js
@@ -8,7 +8,7 @@ import * as API from '../types.js'
  */
 export const ucanRevokeProvider = ({ revocationsStorage }) =>
   provide(revoke, async ({ capability, invocation }) => {
-    // First attempt to resolve linked UCANS to ensure that proof chain
+    // First attempt to resolve linked UCANs to ensure that proof chain
     // has been provided.
     const resolveResult = resolve({ capability, blocks: invocation.blocks })
     if (resolveResult.error) {
@@ -17,7 +17,7 @@ export const ucanRevokeProvider = ({ revocationsStorage }) =>
     const { ucan, principal } = resolveResult.ok
 
     const result =
-      // If the principal is issuer or audience of the UCAN been revoked then
+      // If the principal is issuer or audience of the UCAN being revoked then
       // we can store it as a sole revocation as it will always apply.
       isParticipant(ucan, principal)
         ? await revocationsStorage.reset({

--- a/packages/upload-api/src/utils/revocation.js
+++ b/packages/upload-api/src/utils/revocation.js
@@ -10,7 +10,8 @@ export const create = (context) => ({
 
 /**
  * Verifies that no UCAN in the provided invocation authorization has been
- * revoked. If any of the UCANs had been revoked returns `Revoked` error.
+ * revoked. If any of the UCANs have been revoked it returns a
+ * `Revoked` error.
  *
  * @param {API.RevocationServiceContext} context
  * @param {API.Authorization} auth
@@ -23,7 +24,7 @@ export const validateAuthorization = async ({ revocationsStorage }, auth) => {
   const match = await revocationsStorage.query(query)
 
   // If query failed we also fail the verification. TODO: Define other error
-  // types because here we do not know if ucan had been revoked or not.
+  // types because here we do not know if the UCAN has been revoked or not.
   if (match.error) {
     return { error: new Revoked(auth.delegation) }
   }
@@ -39,7 +40,7 @@ export const validateAuthorization = async ({ revocationsStorage }, auth) => {
     }
   }
 
-  // If no relevant revocation had been found we succeed the verification.
+  // If no relevant revocation has been found we succeed the verification.
   return { ok: {} }
 }
 

--- a/packages/upload-api/src/utils/revocation.js
+++ b/packages/upload-api/src/utils/revocation.js
@@ -1,0 +1,77 @@
+import * as API from '../types.js'
+import { Revoked } from '@ucanto/validator'
+
+/**
+ * @param {API.RevocationServiceContext} context
+ */
+export const create = (context) => ({
+  validateAuthorization: validateAuthorization.bind(null, context),
+})
+
+/**
+ * Verifies that no UCAN in the provided invocation authorization has been
+ * revoked. If any of the UCANs had been revoked returns `Revoked` error.
+ *
+ * @param {API.RevocationServiceContext} context
+ * @param {API.Authorization} auth
+ * @returns {Promise<API.Result<{}, API.Revoked>>}
+ */
+export const validateAuthorization = async ({ revocationsStorage }, auth) => {
+  // Compute map of UCANs to principals with revocation authority.
+  const query = toRevocationQuery(auth)
+  // Fetch all the revocations for all the UCANs in the authorization chain.
+  const match = await revocationsStorage.query(query)
+
+  // If query failed we also fail the verification. TODO: Define other error
+  // types because here we do not know if ucan had been revoked or not.
+  if (match.error) {
+    return { error: new Revoked(auth.delegation) }
+  }
+
+  // Now we go through each revocation and check if revocation issuer has
+  // an authority to revoke the UCAN. If so we fail, otherwise we continue.
+  for (const [ucan, scope = {}] of Object.entries(match.ok)) {
+    for (const principal of /** @type {API.DID[]} */ (Object.keys(scope))) {
+      const delegation = query[ucan]?.[principal]
+      if (delegation) {
+        return { error: new Revoked(delegation) }
+      }
+    }
+  }
+
+  // If no relevant revocation had been found we succeed the verification.
+  return { ok: {} }
+}
+
+/**
+ * Derives revocation query for the given authorization chain. Returned query
+ * is a mapping between delegation CID to map of principals with an authority
+ * to revoke it.
+ *
+ * @param {API.Authorization} authorization
+ * @returns {Record<string, Record<API.DID, API.Delegation>>}
+ */
+
+export const toRevocationQuery = ({ delegation, proofs }) => {
+  // Delegation issuer and audience principals have revocation authority.
+  const scope = {
+    [delegation.issuer.did()]: delegation,
+    [delegation.audience.did()]: delegation,
+  }
+
+  const query = {
+    [delegation.cid.toString()]: scope,
+  }
+
+  // All the principals upstream are also authorized to revoke delegations
+  // downstream, there for we are going to compute queries for each parent
+  // proof and copy their principals into this scope. We are also going to
+  // copy all the CIDs from the parent queries into this query.
+  for (const proof of proofs) {
+    const parent = toRevocationQuery(proof)
+    Object.assign(query, parent)
+    Object.assign(scope, parent[proof.delegation.cid.toString()])
+  }
+
+  return query
+}

--- a/packages/upload-api/test/handlers/ucan.js
+++ b/packages/upload-api/test/handlers/ucan.js
@@ -1,0 +1,264 @@
+import * as API from '../../src/types.js'
+import { alice, bob, mallory } from '../util.js'
+import { UCAN, Console } from '@web3-storage/capabilities'
+
+/**
+ * @type {API.Tests}
+ */
+export const test = {
+  'issuer can revoke delegation': async (assert, context) => {
+    const proof = await Console.log.delegate({
+      issuer: context.id,
+      audience: alice,
+      with: context.id.did(),
+    })
+
+    const success = await Console.log
+      .invoke({
+        issuer: alice,
+        audience: context.id,
+        with: context.id.did(),
+        nb: { value: 'hello' },
+        proofs: [proof],
+      })
+      .execute(context.connection)
+
+    assert.deepEqual(success.out, { ok: 'hello' })
+
+    const revoke = await UCAN.revoke
+      .invoke({
+        issuer: context.id,
+        audience: context.id,
+        with: context.id.did(),
+        nb: {
+          ucan: proof.cid,
+        },
+        proofs: [proof],
+      })
+      .execute(context.connection)
+
+    assert.ok(revoke.out.ok?.time)
+
+    const failure = await Console.log
+      .invoke({
+        issuer: alice,
+        audience: context.id,
+        with: context.id.did(),
+        nb: { value: 'bye' },
+        proofs: [proof],
+      })
+      .execute(context.connection)
+
+    assert.ok(failure.out.error?.message.includes('has been revoked'))
+  },
+
+  'audience can revoke delegation': async (assert, context) => {
+    const proof = await Console.log.delegate({
+      issuer: context.id,
+      audience: alice,
+      with: context.id.did(),
+    })
+
+    const success = await Console.log
+      .invoke({
+        issuer: alice,
+        audience: context.id,
+        with: context.id.did(),
+        nb: { value: 'hello' },
+        proofs: [proof],
+      })
+      .execute(context.connection)
+
+    assert.deepEqual(success.out, { ok: 'hello' })
+
+    const revoke = await UCAN.revoke
+      .invoke({
+        issuer: alice,
+        audience: context.id,
+        with: alice.did(),
+        nb: {
+          ucan: proof.cid,
+        },
+        proofs: [proof],
+      })
+      .execute(context.connection)
+
+    assert.ok(revoke.out.ok?.time)
+
+    const failure = await Console.log
+      .invoke({
+        issuer: alice,
+        audience: context.id,
+        with: context.id.did(),
+        nb: { value: 'bye' },
+        proofs: [proof],
+      })
+      .execute(context.connection)
+
+    assert.ok(failure.out.error?.message.includes('has been revoked'))
+  },
+
+  'issuer can revoke downstream delegation': async (assert, context) => {
+    const proof = await Console.log.delegate({
+      issuer: context.id,
+      audience: alice,
+      with: context.id.did(),
+    })
+
+    const bad = await Console.log.delegate({
+      issuer: alice,
+      audience: bob,
+      with: context.id.did(),
+      proofs: [proof],
+    })
+
+    const good = await Console.log.delegate({
+      issuer: alice,
+      audience: mallory,
+      with: context.id.did(),
+      proofs: [proof],
+    })
+
+    const revoke = await UCAN.revoke
+      .invoke({
+        issuer: context.id,
+        audience: context.id,
+        with: context.id.did(),
+        nb: {
+          ucan: bad.cid,
+        },
+        proofs: [bad],
+      })
+      .execute(context.connection)
+
+    assert.ok(revoke.out.ok?.time)
+
+    const failure = await Console.log
+      .invoke({
+        issuer: bob,
+        audience: context.id,
+        with: context.id.did(),
+        nb: { value: 'boom' },
+        proofs: [bad],
+      })
+      .execute(context.connection)
+
+    assert.ok(failure.out.error?.message.includes('has been revoked'))
+
+    const success = await Console.log
+      .invoke({
+        issuer: mallory,
+        audience: context.id,
+        with: context.id.did(),
+        nb: { value: 'works' },
+        proofs: [good],
+      })
+      .execute(context.connection)
+
+    assert.deepEqual(success.out, { ok: 'works' })
+  },
+
+  'offstream revocations does not apply': async (assert, context) => {
+    const proof = await Console.log.delegate({
+      issuer: context.id,
+      audience: alice,
+      with: context.id.did(),
+    })
+
+    // Bob can revoke but it won't apply since he's not in the delegation chain
+    const revoke = await UCAN.revoke
+      .invoke({
+        issuer: bob,
+        audience: context.id,
+        with: bob.did(),
+        nb: {
+          ucan: proof.cid,
+        },
+        proofs: [proof],
+      })
+      .execute(context.connection)
+    assert.ok(revoke.out.ok?.time)
+
+    const success = await Console.log
+      .invoke({
+        issuer: alice,
+        audience: context.id,
+        with: context.id.did(),
+        nb: { value: 'hello' },
+        proofs: [proof],
+      })
+      .execute(context.connection)
+
+    assert.deepEqual(success.out, { ok: 'hello' })
+  },
+
+  'upstream revocations does not apply': async (assert, context) => {
+    const root = await Console.console.delegate({
+      issuer: context.id,
+      audience: alice,
+      with: context.id.did(),
+    })
+
+    const parent = await Console.log.delegate({
+      issuer: alice,
+      audience: bob,
+      with: context.id.did(),
+      proofs: [root],
+    })
+
+    const child = await Console.log.delegate({
+      issuer: bob,
+      audience: mallory,
+      with: context.id.did(),
+      proofs: [parent],
+    })
+
+    const revoke = await UCAN.revoke
+      .invoke({
+        issuer: bob,
+        audience: context.id,
+        with: bob.did(),
+        nb: {
+          ucan: root.cid,
+        },
+        proofs: [root],
+      })
+      .delegate()
+
+    const [revocation] = await context.connection.execute(revoke)
+
+    assert.ok(revocation.out.ok?.time)
+
+    const revocations = await context.revocationsStorage.query({
+      [root.cid.toString()]: {},
+      [parent.cid.toString()]: {},
+      [child.cid.toString()]: {},
+    })
+
+    assert.deepEqual(
+      JSON.stringify(revocations.ok),
+      JSON.stringify({
+        [root.cid.toString()]: {
+          [bob.did()]: {
+            cause: revoke.cid,
+          },
+        },
+      })
+    )
+
+    // even though bob is principal in the delegation chain, he is downstream
+    // of the delegation he revoked, therefore his revocation does not apply
+
+    const success = await Console.log
+      .invoke({
+        issuer: mallory,
+        audience: context.id,
+        with: context.id.did(),
+        nb: { value: 'hello' },
+        proofs: [child],
+      })
+      .execute(context.connection)
+
+    assert.deepEqual(success.out, { ok: 'hello' })
+  },
+}

--- a/packages/upload-api/test/handlers/ucan.spec.js
+++ b/packages/upload-api/test/handlers/ucan.spec.js
@@ -1,0 +1,30 @@
+/* eslint-disable no-only-tests/no-only-tests */
+import * as UCAN from './ucan.js'
+import * as assert from 'assert'
+import { cleanupContext, createContext } from '../helpers/context.js'
+
+describe('ucan/*', () => {
+  for (const [name, test] of Object.entries(UCAN.test)) {
+    const define = name.startsWith('only ')
+      ? it.only
+      : name.startsWith('skip ')
+      ? it.skip
+      : it
+
+    define(name, async () => {
+      const context = await createContext()
+      try {
+        await test(
+          {
+            equal: assert.strictEqual,
+            deepEqual: assert.deepStrictEqual,
+            ok: assert.ok,
+          },
+          context
+        )
+      } finally {
+        await cleanupContext(context)
+      }
+    })
+  }
+})

--- a/packages/upload-api/test/lib.js
+++ b/packages/upload-api/test/lib.js
@@ -11,7 +11,7 @@ import * as Upload from './handlers/upload.js'
 import { test as delegationsStorageTests } from './storage/delegations-storage-tests.js'
 import { test as provisionsStorageTests } from './storage/provisions-storage-tests.js'
 import { test as rateLimitsStorageTests } from './storage/rate-limits-storage-tests.js'
-import { test as revocationsStorageTests } from './storage/revocations-storage-tests.js' 
+import { test as revocationsStorageTests } from './storage/revocations-storage-tests.js'
 import { DebugEmail } from '../src/utils/email.js'
 
 export * from './util.js'

--- a/packages/upload-api/test/storage/revocations-storage-tests.js
+++ b/packages/upload-api/test/storage/revocations-storage-tests.js
@@ -13,11 +13,12 @@ export const test = {
     const proofRevocation = await createSampleDelegation()
     const invocationCID = await randomCID()
 
-    const { ok: revoked } = await storage.getAll([
-      proofRevocation.cid,
-      badRevocation.cid,
-    ])
-    assert.deepEqual(revoked, [])
+    const notFound = await storage.query({
+      [proofRevocation.cid.toString()]: {},
+      [badRevocation.cid.toString()]: {},
+    })
+
+    assert.deepEqual(notFound, { ok: {} })
 
     await storage.add({
       revoke: badRevocation.cid,
@@ -26,31 +27,42 @@ export const test = {
     })
 
     // it should return revocations that have been recorded
-    const { ok: revocationsToMeta } = await storage.getAll([badRevocation.cid])
-    assert.deepEqual(revocationsToMeta, [
-      {
-        revoke: badRevocation.cid,
-        scope: badRevocation.issuer.did(),
-        cause: invocationCID,
+    const exactMatch = await storage.query({
+      [badRevocation.cid.toString()]: {},
+    })
+
+    assert.deepEqual(exactMatch, {
+      ok: {
+        [badRevocation.cid.toString()]: {
+          [badRevocation.issuer.did()]: {
+            cause: invocationCID,
+          },
+        },
       },
-    ])
+    })
 
     // it should not return revocations that have not been recorded
-    const { ok: noRevocations } = await storage.getAll([proofRevocation.cid])
-    assert.deepEqual(noRevocations, [])
+    const nomatch = await storage.query({
+      [proofRevocation.cid.toString()]: {},
+    })
+
+    assert.deepEqual(nomatch, { ok: {} })
 
     // it should return revocations that have been recorded
-    const { ok: someRevocations } = await storage.getAll([
-      badRevocation.cid,
-      proofRevocation.cid,
-    ])
-    assert.deepEqual(someRevocations, [
-      {
-        revoke: badRevocation.cid,
-        scope: badRevocation.issuer.did(),
-        cause: invocationCID,
+    const partialMatch = await storage.query({
+      [badRevocation.cid.toString()]: {},
+      [proofRevocation.cid.toString()]: {},
+    })
+
+    assert.deepEqual(partialMatch, {
+      ok: {
+        [badRevocation.cid.toString()]: {
+          [badRevocation.issuer.did()]: {
+            cause: invocationCID,
+          },
+        },
       },
-    ])
+    })
   },
 
   'can reset revocations': async (assert, context) => {
@@ -69,19 +81,17 @@ export const test = {
       scope: bob.did(),
     })
 
-    assert.deepEqual(await storage.getAll([revoke]), {
-      ok: [
-        {
-          revoke,
-          cause,
-          scope: alice.did(),
+    assert.deepEqual(await storage.query({ [revoke.toString()]: {} }), {
+      ok: {
+        [revoke.toString()]: {
+          [alice.did()]: {
+            cause,
+          },
+          [bob.did()]: {
+            cause,
+          },
         },
-        {
-          revoke,
-          cause,
-          scope: bob.did(),
-        },
-      ],
+      },
     })
 
     await storage.reset({
@@ -90,14 +100,14 @@ export const test = {
       scope: mallory.did(),
     })
 
-    assert.deepEqual(await storage.getAll([revoke]), {
-      ok: [
-        {
-          revoke,
-          cause,
-          scope: mallory.did(),
+    assert.deepEqual(await storage.query({ [revoke.toString()]: {} }), {
+      ok: {
+        [revoke.toString()]: {
+          [mallory.did()]: {
+            cause,
+          },
         },
-      ],
+      },
     })
   },
 }

--- a/packages/upload-api/test/storage/revocations-storage.js
+++ b/packages/upload-api/test/storage/revocations-storage.js
@@ -6,7 +6,7 @@ import * as Types from '../../src/types.js'
 export class RevocationsStorage {
   constructor() {
     /**
-     * @type {Array<Types.Delegation<Types.Tuple<any>>>}
+     * @type {Array<Types.Delegation>}
      */
     this.delegations = []
 
@@ -18,14 +18,23 @@ export class RevocationsStorage {
 
   /**
    *
-   * @param {Types.Link[]} delegationCids
-   * @returns
+   * @param {Types.RevocationQuery} ucans
    */
-  async getAll(delegationCids) {
-    const revoked = new Set(delegationCids.map((c) => c.toString()))
-    return {
-      ok: this.revocations.filter((r) => revoked.has(r.revoke.toString())),
+  async query(ucans) {
+    const { revocations } = this
+    /** @type {Types.MatchingRevocations} */
+    const matches = {}
+    for (const { revoke, scope, ...output } of revocations) {
+      const key = /** @type {Types.ToString<Types.UCANLink>} */ (`${revoke}`)
+
+      if (ucans[key]) {
+        const match = matches[key] || {}
+        match[scope] = output
+        matches[key] = match
+      }
     }
+
+    return { ok: matches }
   }
 
   /**
@@ -36,6 +45,7 @@ export class RevocationsStorage {
     this.revocations = [...this.revocations, revocation]
     return { ok: {} }
   }
+
   /**
    * @param {Types.Revocation} revocation
    */

--- a/packages/upload-api/test/storage/revocations-storage.js
+++ b/packages/upload-api/test/storage/revocations-storage.js
@@ -17,22 +17,36 @@ export class RevocationsStorage {
   }
 
   /**
-   * 
-   * @param {Types.Link[]} delegationCids 
-   * @returns 
+   *
+   * @param {Types.Link[]} delegationCids
+   * @returns
    */
   async getAll(delegationCids) {
-    const revoked = new Set(delegationCids.map(c => c.toString()))
-    return { ok: this.revocations.filter(r => revoked.has(r.revoke.toString())) }
+    const revoked = new Set(delegationCids.map((c) => c.toString()))
+    return {
+      ok: this.revocations.filter((r) => revoked.has(r.revoke.toString())),
+    }
   }
 
   /**
-   * 
-   * @param {Types.Revocation[]} revocations
-   * @returns 
+   *
+   * @param {Types.Revocation} revocation
    */
-  async addAll(revocations) {
-    this.revocations = this.revocations.concat(revocations)
+  async add(revocation) {
+    this.revocations = [...this.revocations, revocation]
+    return { ok: {} }
+  }
+  /**
+   * @param {Types.Revocation} revocation
+   */
+  async reset(revocation) {
+    this.revocations = [
+      ...this.revocations.filter(
+        (r) => r.revoke.toString() !== revocation.revoke.toString()
+      ),
+      revocation,
+    ]
+
     return { ok: {} }
   }
 }


### PR DESCRIPTION
Implements `ucan/revoke` capability and a ucanto server hook that performs the revocation checks.

I ended up changing revocations store interface to avoid serializing / deserializing UCN CIDs and to layout data in a way that it's would be more efficient to perform necessary lookups.

☹️ I'm not super happy about the way we have to interface with ucanto hook and probably it would make sense to change hook API so it's more like `query` on the revocations store. If we do that we would be able to uplift logic from `utils/revocation.js` into ucanto and simplify things here. That said I it's probably better to land thing here first and do the uplifting if we'll have time to do so.