### PR TITLE
chore: ignore VSCode settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# VSCode settings
+.vscode/settings.json


### PR DESCRIPTION
I keep accidentally checking this in, so let's ignore it