### PR TITLE
fix: do not log warning on failed retry

### DIFF
--- a/packages/upload-client/src/store.js
+++ b/packages/upload-client/src/store.js
@@ -124,7 +124,6 @@ export async function add(
       }
     },
     {
-      onFailedAttempt: console.warn,
       retries: options.retries ?? REQUEST_RETRIES,
     }
   )


### PR DESCRIPTION
Is misleading to users - looks like things have failed when they are being retried automatically.