### PR TITLE
feat: allow customers to create more than one space

### DIFF
--- a/packages/upload-api/test/handlers/upload.js
+++ b/packages/upload-api/test/handlers/upload.js
@@ -420,9 +420,7 @@ export const test = {
     )
   },
 
-  // skip for now since it's not possible for a single account to register multiple spaces
-  // TODO: revisit whether this is a reasonable assumption in tests
-  'skip upload/remove only removes an upload for the given space': async (
+  'upload/remove only removes an upload for the given space': async (
     assert,
     context
   ) => {

--- a/packages/upload-api/test/storage/provisions-storage.js
+++ b/packages/upload-api/test/storage/provisions-storage.js
@@ -5,7 +5,7 @@ import * as Types from '../../src/types.js'
  * @param {Types.Provision} item
  * @returns {string}
  */
-const itemKey = (item) => `${item.customer}@${item.provider}`
+const itemKey = ({customer, consumer, provider}) => `${customer}:${consumer}@${provider}`
 
 /**
  * @implements {Types.ProvisionsStorage}


### PR DESCRIPTION
this just updates the test `ProvisionsStorage` to behave the way the production `ProvisionsStorage` does as of https://github.com/web3-storage/w3infra/pull/246