### PR TITLE
feat: add more capabilities to the set we request on authorize

### DIFF
--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -184,7 +184,7 @@ export async function authorizeAndWait(access, email, opts = {}) {
       { can: 'upload/*' },
       { can: 'ucan/*' },
       { can: 'plan/*' },
-      { can: 'w3up/*' }
+      { can: 'w3up/*' },
     ]
   )
   const sessionDelegations = [...(await expectAuthorization(access, opts))]

--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -182,6 +182,9 @@ export async function authorizeAndWait(access, email, opts = {}) {
       { can: 'store/*' },
       { can: 'provider/add' },
       { can: 'upload/*' },
+      { can: 'ucan/*' },
+      { can: 'plan/*' },
+      { can: 'w3up/*' }
     ]
   )
   const sessionDelegations = [...(await expectAuthorization(access, opts))]


### PR DESCRIPTION
this should get us through the next major round of product features, and adds a `w3up` namespace that we can use (or at least alias into) for future capabilities