### PR TITLE
chore: export more types to filecoin api

### DIFF
--- a/packages/filecoin-api/package.json
+++ b/packages/filecoin-api/package.json
@@ -14,17 +14,26 @@
       "src/lib.js": [
         "dist/src/lib.d.ts"
       ],
+      "aggregator/api": [
+        "dist/src/aggregator/api.d.ts"
+      ],
       "aggregator/service": [
         "dist/src/aggregator/service.d.ts"
       ],
       "aggregator/events": [
         "dist/src/aggregator/events.d.ts"
       ],
+      "dealer/api": [
+        "dist/src/dealer/api.d.ts"
+      ],
       "dealer/service": [
         "dist/src/dealer/service.d.ts"
       ],
       "dealer/events": [
         "dist/src/dealer/events.d.ts"
+      ],
+      "deal-tracker/api": [
+        "dist/src/deal-tracker/api.d.ts"
       ],
       "deal-tracker/service": [
         "dist/src/deal-tracker/service.d.ts"
@@ -34,6 +43,9 @@
       ],
       "errors": [
         "dist/src/errors.d.ts"
+      ],
+      "storefront/api": [
+        "dist/src/storefront/api.d.ts"
       ],
       "storefront/service": [
         "dist/src/storefront/service.d.ts"
@@ -61,6 +73,10 @@
       "types": "./dist/src/types.d.ts",
       "import": "./src/types.js"
     },
+    "./aggregator/api": {
+      "types": "./dist/src/aggregator/api.d.ts",
+      "import": "./src/aggregator/api.js"
+    },
     "./aggregator/service": {
       "types": "./dist/src/aggregator/service.d.ts",
       "import": "./src/aggregator/service.js"
@@ -68,6 +84,10 @@
     "./aggregator/events": {
       "types": "./dist/src/aggregator/events.d.ts",
       "import": "./src/aggregator/events.js"
+    },
+    "./dealer/api": {
+      "types": "./dist/src/dealer/api.d.ts",
+      "import": "./src/dealer/api.js"
     },
     "./dealer/service": {
       "types": "./dist/src/dealer/service.d.ts",
@@ -77,9 +97,17 @@
       "types": "./dist/src/dealer/events.d.ts",
       "import": "./src/dealer/events.js"
     },
+    "./deal-tracker/api": {
+      "types": "./dist/src/deal-tracker/api.d.ts",
+      "import": "./src/deal-tracker/api.js"
+    },
     "./deal-tracker/service": {
       "types": "./dist/src/deal-tracker/service.d.ts",
       "import": "./src/deal-tracker/service.js"
+    },
+    "./storefront/api": {
+      "types": "./dist/src/storefront/api.d.ts",
+      "import": "./src/storefront/api.js"
     },
     "./storefront/service": {
       "types": "./dist/src/storefront/service.d.ts",

--- a/packages/filecoin-api/src/aggregator/api.ts
+++ b/packages/filecoin-api/src/aggregator/api.ts
@@ -13,6 +13,15 @@ import {
   ServiceConfig,
 } from '../types.js'
 
+export type PieceStore = UpdatableStore<PieceRecordKey, PieceRecord>
+export type PieceQueue = Queue<PieceMessage>
+export type BufferQueue = Queue<BufferMessage>
+export type BufferStore = Store<Link, BufferRecord>
+export type AggregateStore = Store<AggregateRecordKey, AggregateRecord>
+export type PieceAcceptQueue = Queue<PieceAcceptMessage>
+export type InclusionStore = QueryableStore<InclusionRecordKey, InclusionRecord, InclusionRecordQueryByGroup>
+export type AggregateOfferQueue = Queue<AggregateOfferMessage>
+
 export interface ServiceContext {
   /**
    * Service signer
@@ -25,39 +34,35 @@ export interface ServiceContext {
   /**
    * Stores pieces that have been offered to the aggregator.
    */
-  pieceStore: UpdatableStore<PieceRecordKey, PieceRecord>
+  pieceStore: PieceStore
   /**
    * Queues pieces being buffered into an aggregate.
    */
-  pieceQueue: Queue<PieceMessage>
+  pieceQueue: PieceQueue
   /**
    * Queues pieces being buffered into an aggregate.
    */
-  bufferQueue: Queue<BufferMessage>
+  bufferQueue: BufferQueue
   /**
    * Store of CID => Buffer Record
    */
-  bufferStore: Store<Link, BufferRecord>
+  bufferStore: BufferStore
   /**
    * Stores fully buffered aggregates.
    */
-  aggregateStore: Store<AggregateRecordKey, AggregateRecord>
+  aggregateStore: AggregateStore
   /**
    * Queues pieces, their aggregate and their inclusion proofs.
    */
-  pieceAcceptQueue: Queue<PieceAcceptMessage>
+  pieceAcceptQueue: PieceAcceptQueue
   /**
    * Stores inclusion proofs for pieces included in an aggregate.
    */
-  inclusionStore: QueryableStore<
-    InclusionRecordKey,
-    InclusionRecord,
-    InclusionRecordQueryByGroup
-  >
+  inclusionStore: InclusionStore
   /**
    * Queues buffered aggregates to be offered to the Dealer.
    */
-  aggregateOfferQueue: Queue<AggregateOfferMessage>
+  aggregateOfferQueue: AggregateOfferQueue
 }
 
 export interface PieceMessageContext

--- a/packages/filecoin-api/src/deal-tracker/api.ts
+++ b/packages/filecoin-api/src/deal-tracker/api.ts
@@ -2,6 +2,8 @@ import type { Signer } from '@ucanto/interface'
 import { PieceLink } from '@web3-storage/data-segment'
 import { QueryableStore } from '../types.js'
 
+export type DealStore = QueryableStore<DealRecordKey, DealRecord, DealRecordQueryByPiece>
+
 export interface ServiceContext {
   /**
    * Service signer
@@ -11,7 +13,7 @@ export interface ServiceContext {
   /**
    * Stores information about deals for a given aggregate piece CID.
    */
-  dealStore: QueryableStore<DealRecordKey, DealRecord, DealRecordQueryByPiece>
+  dealStore: DealStore
 }
 
 export interface DealRecord {

--- a/packages/filecoin-api/src/storefront/api.ts
+++ b/packages/filecoin-api/src/storefront/api.ts
@@ -18,6 +18,12 @@ import {
   ServiceConfig,
 } from '../types.js'
 
+export type PieceStore = UpdatableAndQueryableStore<PieceRecordKey, PieceRecord, Pick<PieceRecord, 'status'>>
+export type FilecoinSubmitQueue = Queue<FilecoinSubmitMessage>
+export type PieceOfferQueue = Queue<PieceOfferMessage>
+export type TaskStore = Store<UnknownLink, Invocation>
+export type ReceiptStore = Store<UnknownLink, Receipt>
+
 export interface ServiceOptions {
   /**
    * Implementer MAY handle submission without user request.
@@ -37,27 +43,23 @@ export interface ServiceContext {
   /**
    * Stores pieces that have been offered to the Storefront.
    */
-  pieceStore: UpdatableAndQueryableStore<
-    PieceRecordKey,
-    PieceRecord,
-    Pick<PieceRecord, 'status'>
-  >
+  pieceStore: PieceStore
   /**
    * Queues pieces for verification.
    */
-  filecoinSubmitQueue: Queue<FilecoinSubmitMessage>
+  filecoinSubmitQueue: FilecoinSubmitQueue
   /**
    * Queues pieces for offering to an Aggregator.
    */
-  pieceOfferQueue: Queue<PieceOfferMessage>
+  pieceOfferQueue: PieceOfferQueue
   /**
    * Stores task invocations.
    */
-  taskStore: Store<UnknownLink, Invocation>
+  taskStore: TaskStore
   /**
    * Stores receipts for tasks.
    */
-  receiptStore: Store<UnknownLink, Receipt>
+  receiptStore: ReceiptStore
   /**
    * Service options.
    */


### PR DESCRIPTION
Adds more exports of types to ease usage