### PR TITLE
fix: package.json files excludes 'src' and includes .js and .js.map in dist for packages that now export their module from dist 

### DIFF
--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -52,7 +52,8 @@
     }
   },
   "files": [
-    "src",
+    "dist/src/**/*.js",
+    "dist/src/**/*.js.map",
     "dist/src/**/*.d.ts",
     "dist/src/**/*.d.ts.map"
   ],

--- a/packages/filecoin-client/package.json
+++ b/packages/filecoin-client/package.json
@@ -51,7 +51,8 @@
     }
   },
   "files": [
-    "src",
+    "dist/src/**/*.js",
+    "dist/src/**/*.js.map",
     "dist/src/**/*.d.ts",
     "dist/src/**/*.d.ts.map"
   ],

--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -60,7 +60,8 @@
     }
   },
   "files": [
-    "src",
+    "dist/src/**/*.js",
+    "dist/src/**/*.js.map",
     "dist/src/**/*.d.ts",
     "dist/src/**/*.d.ts.map"
   ],


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/w3up/pull/1004/files#r1372070039