### PR TITLE
ci: filecoin-client github workflow runs arethetypesworking tooling, passes due to removal of chain-tracker export

### DIFF
--- a/.github/workflows/filecoin-client.yml
+++ b/.github/workflows/filecoin-client.yml
@@ -36,3 +36,4 @@ jobs:
       - run: pnpm run build
       - run: pnpm -r --filter @web3-storage/filecoin-client run lint
       - run: pnpm -r --filter @web3-storage/filecoin-client run test
+      - run: pnpm -r --filter @web3-storage/filecoin-client run attw

--- a/packages/filecoin-client/package.json
+++ b/packages/filecoin-client/package.json
@@ -27,7 +27,6 @@
     ".": "./dist/src/index.js",
     "./aggregator": "./dist/src/aggregator.js",
     "./dealer": "./dist/src/dealer.js",
-    "./chain-tracker": "./dist/src/chain-tracker.js",
     "./storefront": "./dist/src/storefront.js",
     "./types": "./dist/src/types.js"
   },
@@ -41,9 +40,6 @@
       ],
       "dealer": [
         "dist/src/dealer.d.ts"
-      ],
-      "chain-tracker": [
-        "dist/src/chain-tracker.d.ts"
       ],
       "storefront": [
         "dist/src/storefront.d.ts"


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/w3up/issues/982
  * I was testing the filecoin-client 2.0.1 release I did against attw and noticed it actually still fails for a tiny reason. https://arethetypeswrong.github.io/?p=%40web3-storage%2Ffilecoin-client%402.0.1

Change
* now CI for filecoin-client will use attw to prevent releases like this that dont pass attw check
* also update package.json to resolve the attw update for filecoin-client