### PR TITLE
fix: aggregate accept must query with aggregate only

### DIFF
--- a/packages/filecoin-api/src/dealer/api.ts
+++ b/packages/filecoin-api/src/dealer/api.ts
@@ -15,7 +15,7 @@ export type OfferStore<OfferDoc> = UpdatableStore<string, OfferDoc>
 export type AggregateStore = UpdatableAndQueryableStore<
   AggregateRecordKey,
   AggregateRecord,
-  Pick<AggregateRecord, 'status'>
+  Pick<AggregateRecord, 'status'> | Pick<AggregateRecord, 'aggregate'>
 >
 
 export interface ServiceContext<OfferDoc = OfferDocument> {

--- a/packages/filecoin-api/src/dealer/service.js
+++ b/packages/filecoin-api/src/dealer/service.js
@@ -95,15 +95,17 @@ export const aggregateAccept = async ({ capability }, context) => {
   const { aggregate } = capability.nb
 
   // Get deal status from the store.
-  const get = await context.aggregateStore.get({
+  const query = await context.aggregateStore.query({
     aggregate,
   })
-  if (get.error) {
+  if (query.error) {
     return {
-      error: new StoreOperationFailed(get.error.message),
+      error: new StoreOperationFailed(query.error.message),
     }
   }
-  if (!get.ok.deal) {
+  // We just care about one deal for issuing receipt
+  const succeededAggregate = query.ok.find(r => r.deal)
+  if (!succeededAggregate?.deal) {
     return {
       error: new StoreOperationFailed('no deal available'),
     }
@@ -112,8 +114,8 @@ export const aggregateAccept = async ({ capability }, context) => {
   return {
     ok: {
       aggregate,
-      dataSource: get.ok.deal.dataSource,
-      dataType: get.ok.deal.dataType,
+      dataSource: succeededAggregate.deal.dataSource,
+      dataType: succeededAggregate.deal.dataType,
     },
   }
 }

--- a/packages/filecoin-api/test/context/store-implementations.js
+++ b/packages/filecoin-api/test/context/store-implementations.js
@@ -170,7 +170,7 @@ export const getStoreImplementations = (
         /** @type {Set<DealerAggregateRecord>} */ items,
         /** @type {Partial<DealerAggregateRecord>} */ search
       ) => {
-        return Array.from(items).filter((i) => i.status === search.status)
+        return Array.from(items).filter((i) => i.status === search.status || i.aggregate.equals(search.aggregate))
       },
       updateFn: (
         /** @type {Set<DealerAggregateRecord>} */ items,


### PR DESCRIPTION
While implementing, noticed that the key of table also includes deal which we don't have. However, we just need to query for an aggregate having a deal.