### PR TITLE
feat!: update space creation logic

### DIFF
--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -74,7 +74,8 @@
     "one-webcrypto": "git://github.com/web3-storage/one-webcrypto",
     "p-defer": "^4.0.0",
     "type-fest": "^3.3.0",
-    "uint8arrays": "^4.0.6"
+    "uint8arrays": "^4.0.6",
+    "@scure/bip39": "^1.2.1"
   },
   "devDependencies": {
     "@types/assert": "^1.5.6",

--- a/packages/access-client/src/access.js
+++ b/packages/access-client/src/access.js
@@ -1,0 +1,41 @@
+import * as Access from '@web3-storage/capabilities/access'
+import * as Ucanto from '@ucanto/interface'
+import { fail } from '@ucanto/core'
+import { Agent } from './agent.js'
+
+/**
+ * Takes array of delegations and propagates them to their respective audiences
+ * through a given space (or the current space if none is provided).
+ *
+ * Returns error result if agent has no current space and no space was provided.
+ * Also returns error result if invocation fails.
+ *
+ * @param {Agent} agent - Agent connected to the w3up service.
+ * @param {object} input
+ * @param {Ucanto.Delegation[]} input.delegations - Delegations to propagate.
+ * @param {Ucanto.DID} [input.space] - Space to propagate through.
+ */
+export const delegate = async (
+  agent,
+  { delegations, space = agent.currentSpace() }
+) => {
+  if (!space) {
+    return fail('Space must be specified')
+  }
+
+  const entries = Object.values(delegations).map((proof) => [
+    proof.cid.toString(),
+    proof.cid,
+  ])
+
+  const { out } = await agent.invokeAndExecute(Access.delegate, {
+    with: space,
+    nb: {
+      delegations: Object.fromEntries(entries),
+    },
+    // must be embedded here because it's referenced by cid in .nb.delegations
+    proofs: delegations,
+  })
+
+  return out
+}

--- a/packages/access-client/src/agent-data.js
+++ b/packages/access-client/src/agent-data.js
@@ -3,7 +3,7 @@ import { Signer as EdSigner } from '@ucanto/principal/ed25519'
 import { importDAG } from '@ucanto/core/delegation'
 import * as Ucanto from '@ucanto/interface'
 import { CID } from 'multiformats'
-import { Access } from '@web3-storage/capabilities'
+import { UCAN } from '@web3-storage/capabilities'
 import { isExpired } from './delegations.js'
 
 /** @typedef {import('./types.js').AgentDataModel} AgentDataModel */
@@ -156,13 +156,13 @@ export class AgentData {
  * @param {Ucanto.Capability} cap
  * @returns {boolean}
  */
-const isSessionCapability = (cap) => cap.can === Access.session.can
+const isSessionCapability = (cap) => cap.can === UCAN.attest.can
 
 /**
  * Is the given delegation a session proof?
  *
  * @param {Ucanto.Delegation} delegation
- * @returns {delegation is Ucanto.Delegation<[import('./types.js').AccessSession]>}
+ * @returns {delegation is Ucanto.Delegation<[import('./types.js').UCANAttest]>}
  */
 export const isSessionProof = (delegation) =>
   delegation.capabilities.some((cap) => isSessionCapability(cap))

--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -250,7 +250,7 @@ export async function addProviderAndDelegateToAccount(
     throw new Error('No space selected')
   }
 
-  if (spaceMeta && spaceMeta.isRegistered) {
+  if (spaceMeta) {
     throw new Error('Space already registered with web3.storage.')
   }
   const account = { did: () => DidMailto.fromEmail(DidMailto.email(email)) }
@@ -263,7 +263,7 @@ export async function addProviderAndDelegateToAccount(
   if (delegateSpaceAccessResult.out.error) {
     throw delegateSpaceAccessResult.out.error
   }
-  spaceMeta.isRegistered = true
+
   await agentData.addSpace(space, spaceMeta)
 }
 

--- a/packages/access-client/src/space.js
+++ b/packages/access-client/src/space.js
@@ -1,0 +1,205 @@
+import * as ED25519 from '@ucanto/principal/ed25519'
+import * as Ucanto from '@ucanto/interface'
+import { delegate, Schema } from '@ucanto/core'
+import * as BIP39 from '@scure/bip39'
+import { wordlist } from '@scure/bip39/wordlists/english'
+
+/**
+ * @typedef {object} Model
+ * @property {ED25519.EdSigner} signer
+ * @property {string} name
+ */
+
+/**
+ * Generates a new space.
+ *
+ * @param {object} options
+ * @param {string} options.name
+ */
+export const generate = async ({ name }) => {
+  const { signer } = await ED25519.generate()
+
+  return new OwnedSpace({ signer, name })
+}
+
+/**
+ * Recovers space from the mnemonic.
+ *
+ * @param {string} mnemonic
+ * @param {object} options
+ * @param {string} options.name
+ */
+export const fromMnemonic = async (mnemonic, { name }) => {
+  const secret = BIP39.mnemonicToEntropy(mnemonic, wordlist)
+  const signer = await ED25519.derive(secret)
+  return new OwnedSpace({ signer, name })
+}
+
+/**
+ * @param {object} space
+ * @param {ED25519.EdSigner} space.signer
+ */
+export const toMnemonic = ({ signer }) => {
+  /** @type {Uint8Array} */
+  // @ts-expect-error - Field is defined but not in the interface
+  const secret = signer.secret
+
+  return BIP39.entropyToMnemonic(secret, wordlist)
+}
+
+/**
+ * Creates a (UCAN) delegation that gives full access to the space to the
+ * specified `account`. At the moment we only allow `did:mailto` principal
+ * to be used as an `account`.
+ *
+ * @param {Model} space
+ * @param {Ucanto.DID<'mailto'>} account
+ */
+export const createRecovery = async ({ signer, name }, account) => {
+  return await delegate({
+    issuer: signer,
+    audience: signer.withDID(account),
+    capabilities: [{ with: signer.did(), can: '*' }],
+    expiration: Infinity,
+    facts: [{ space: { name } }],
+  })
+}
+
+/**
+ * Creates (UCAN) delegation that gives specified `agent` an access to
+ * specified ability (passed as `access.can` field) on the this space.
+ * Optionally, you can specify `access.expiration` field to set the
+ *
+ * @param {Model} space
+ * @param {Ucanto.Principal} agent
+ * @param {object} access
+ * @param {Ucanto.Ability} access.can
+ * @param {Ucanto.UCAN.UTCUnixTimestamp} access.expiration
+ */
+export const createAuthorization = async (
+  { signer, name },
+  agent,
+  { can, expiration }
+) => {
+  return await delegate({
+    issuer: signer,
+    audience: agent,
+    capabilities: [{ with: signer.did(), can }],
+    ...(expiration ? { expiration } : {}),
+    facts: [{ space: { name } }],
+  })
+}
+
+class OwnedSpace {
+  /**
+   * @param {object} input
+   * @param {ED25519.EdSigner} input.signer
+   * @param {string} input.name
+   */
+  constructor({ signer, name }) {
+    this.signer = signer
+    this.name = name
+  }
+
+  did() {
+    return this.signer.did()
+  }
+
+  /**
+   *
+   * @param {string} name
+   */
+  withName(name) {
+    return new OwnedSpace({ signer: this.signer, name })
+  }
+
+  /**
+   * Creates a (UCAN) delegation that gives full access to the space to the
+   * specified `account`. At the moment we only allow `did:mailto` principal
+   * to be used as an `account`.
+   *
+   * @param {Ucanto.DID<'mailto'>} account
+   */
+  async createRecovery(account) {
+    return createRecovery(this, account)
+  }
+
+  /**
+   * Creates (UCAN) delegation that gives specified `agent` an access to
+   * specified ability (passed as `access.can` field) on the this space.
+   * Optionally, you can specify `access.expiration` field to set the
+   *
+   * @param {Ucanto.Principal} agent
+   * @param {object} access
+   * @param {Ucanto.Ability} access.can
+   * @param {Ucanto.UCAN.UTCUnixTimestamp} access.expiration
+   */
+  createAuthorization(agent, access) {
+    return createAuthorization(this, agent, access)
+  }
+
+  /**
+   * Derives BIP39 mnemonic that can be used to recover the space.
+   *
+   * @returns {string}
+   */
+  toMnemonic() {
+    return toMnemonic(this)
+  }
+}
+
+/**
+ *
+ * @param {Ucanto.Delegation} delegation
+ */
+export const fromDelegation = (delegation) => {
+  const result = Schema.DID.read(delegation.capabilities[0].with)
+  if (result.error) {
+    throw Object.assign(
+      new Error(
+        `Invalid delegation, expected capabilities[0].with to be DID, ${result.error}`
+      ),
+      {
+        cause: result.error,
+      }
+    )
+  }
+
+  /** @type {{name?:string}} */
+  const meta = delegation.facts[0]?.space ?? {}
+
+  return new SharedSpace({ id: result.ok, delegation, meta })
+}
+
+class SharedSpace {
+  /**
+   * @param {object} input
+   * @param {Ucanto.DID} input.id
+   * @param {Ucanto.Delegation} input.delegation
+   * @param {{name?:string}} input.meta
+   */
+  constructor({ id, delegation, meta }) {
+    this.delegation = delegation
+    this.id = id
+    this.meta = meta
+  }
+
+  get name() {
+    return this.meta.name ?? ''
+  }
+
+  /**
+   * @param {string} name
+   */
+  withName(name) {
+    return new SharedSpace({
+      id: this.id,
+      delegation: this.delegation,
+      meta: { ...this.meta, name },
+    })
+  }
+
+  did() {
+    return this.id
+  }
+}

--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -157,11 +157,7 @@ export interface SpaceMeta {
   /**
    * Human readable name for the space
    */
-  name?: string
-  /**
-   * Was this space already registered with w3up?
-   */
-  isRegistered: boolean
+  name: string
 }
 
 /**

--- a/packages/access-client/src/utils/nickname.js
+++ b/packages/access-client/src/utils/nickname.js
@@ -1,0 +1,55 @@
+// @ts-nocheck
+import { predicates, objects } from 'friendly-words'
+
+/**
+ * Takes cryptographic hash and derives a human readable nickname from it. Note
+ * that this is not a reversible operation. The nickname is not guaranteed to be
+ * unique however the larger the word list in the vocabulary the less likely it
+ * is that there will be a collision.
+ *
+ * @param {Uint8Array} hash
+ * @param {Array<string[]>} [vocabulary]
+ * @returns {string}
+ */
+export const toNickname = (hash, vocabulary = [predicates, objects]) =>
+  toWords(hash, vocabulary).join('-')
+
+/**
+ * Takes cryptographic hash and derives a set of words from the given vocabulary.
+ * Number of returned words will correspond to the number of words in the
+ * vocabulary. Greater the number of words in each vocabulary list the less
+ * likely it is that there will be a collision.
+ *
+ * @param {Uint8Array} hash
+ * @param {Array<string[]>} vocabulary
+ * @returns {string[]}
+ */
+export const toWords = (hash, vocabulary) => {
+  const wordCount = vocabulary.length
+  const sectionSize = Math.ceil(hash.length / wordCount)
+  const nameParts = []
+
+  for (const [index, words] of vocabulary.entries()) {
+    const start = index * sectionSize
+    const end = Math.min(start + sectionSize, hash.length)
+    const wordIndex = combineBytes(hash.subarray(start, end), words.length)
+    nameParts.push(words[wordIndex])
+  }
+
+  return nameParts
+}
+
+/**
+ * Combine given bytes into a single number between 0 and `capacity`.
+ *
+ * @param {Uint8Array} bytes
+ * @param {number} capacity
+ */
+export const combineBytes = (bytes, capacity) => {
+  let combinedValue = 0
+  for (const byte of bytes) {
+    combinedValue = (combinedValue * 256 + byte) % capacity
+  }
+
+  return combinedValue
+}

--- a/packages/access-client/test/agent-use-cases.test.js
+++ b/packages/access-client/test/agent-use-cases.test.js
@@ -2,6 +2,7 @@ import assert from 'assert'
 import sinon from 'sinon'
 import * as Server from '@ucanto/server'
 import * as Access from '@web3-storage/capabilities/access'
+import * as Ucan from '@web3-storage/capabilities/ucan'
 import * as Space from '@web3-storage/capabilities/space'
 import { Agent, connection } from '../src/agent.js'
 import {
@@ -16,7 +17,7 @@ import { delegationsToBytes } from '../src/encoding.js'
 describe('delegationsIncludeSessionProof', function () {
   it('should return true if and only if one of the delegations is a session proof', async function () {
     const agent = await Agent.create()
-    const sessionProof = await Access.session.delegate({
+    const sessionProof = await Ucan.attest.delegate({
       issuer: agent.issuer,
       audience: fixtures.service,
       with: fixtures.alice.did(),
@@ -53,7 +54,7 @@ describe('authorizeWaitAndClaim', async function () {
       audience: agent.issuer,
       with: fixtures.alice.did(),
     })
-    const sessionProof = await Access.session.delegate({
+    const sessionProof = await Ucan.attest.delegate({
       issuer: agent.issuer,
       audience: agent.issuer,
       with: fixtures.alice.did(),

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -18,7 +18,7 @@ describe('Agent', function () {
     const agent = await Agent.create()
     const space = await agent.createSpace('test-create')
 
-    assert(typeof space.did === 'string')
+    assert(typeof space.did() === 'string')
   })
 
   it('should add proof when creating acccount', async function () {
@@ -51,7 +51,7 @@ describe('Agent', function () {
     if (!accWithMeta) {
       assert.fail('should have space')
     }
-    assert.equal(accWithMeta.did, space.did)
+    assert.equal(accWithMeta.did, space.did())
     assert(accWithMeta.proofs.length === 1)
     assert.deepStrictEqual(accWithMeta.capabilities, ['*'])
   })
@@ -255,7 +255,7 @@ describe('Agent', function () {
     assert.deepStrictEqual(out.capabilities, [
       {
         can: '*',
-        with: space.did,
+        with: space.did(),
       },
     ])
   })

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -19,22 +19,33 @@ describe('Agent', function () {
     const space = await agent.createSpace('test-create')
 
     assert(typeof space.did === 'string')
-    assert(space.proof)
   })
 
   it('should add proof when creating acccount', async function () {
     const agent = await Agent.create()
     const space = await agent.createSpace('test-add')
+    const authorization = await space.createAuthorization(agent, {
+      can: '*',
+      expiration: Infinity,
+    })
+
+    await agent.importSpaceFromDelegation(authorization)
     const delegations = agent.proofs()
 
-    assert.equal(space.proof.cid, delegations[0].cid)
+    assert.equal(authorization.cid, delegations[0].cid)
   })
 
   it('should set current space', async function () {
     const agent = await Agent.create()
     const space = await agent.createSpace('test')
+    const authorization = await space.createAuthorization(agent, {
+      can: '*',
+      expiration: Infinity,
+    })
 
-    await agent.setCurrentSpace(space.did)
+    await agent.importSpaceFromDelegation(authorization)
+
+    await agent.setCurrentSpace(space.did())
 
     const accWithMeta = await agent.currentSpaceWithMeta()
     if (!accWithMeta) {
@@ -63,7 +74,12 @@ describe('Agent', function () {
     const bob = await Agent.create()
 
     const space = await alice.createSpace('videos')
-    await alice.setCurrentSpace(space.did)
+    const auth = await space.createAuthorization(alice, {
+      can: '*',
+      expiration: Infinity,
+    })
+    await alice.importSpaceFromDelegation(auth)
+    await alice.setCurrentSpace(space.did())
 
     const proof = await alice.delegate({
       audience: bob,
@@ -72,9 +88,9 @@ describe('Agent', function () {
     })
 
     await bob.importSpaceFromDelegation(proof)
-    await bob.setCurrentSpace(space.did)
+    await bob.setCurrentSpace(space.did())
 
-    const proofs = bob.proofs([{ can: 'store/add', with: space.did }])
+    const proofs = bob.proofs([{ can: 'store/add', with: space.did() }])
     assert(proofs.length)
   })
 
@@ -83,7 +99,12 @@ describe('Agent', function () {
     const bob = await Agent.create()
 
     const space = await alice.createSpace('videos')
-    await alice.setCurrentSpace(space.did)
+    const auth = await space.createAuthorization(alice, {
+      can: '*',
+      expiration: Infinity,
+    })
+    await alice.importSpaceFromDelegation(auth)
+    await alice.setCurrentSpace(space.did())
 
     const proof = await alice.delegate({
       audience: bob,
@@ -92,9 +113,9 @@ describe('Agent', function () {
     })
 
     await bob.importSpaceFromDelegation(proof)
-    await bob.setCurrentSpace(space.did)
+    await bob.setCurrentSpace(space.did())
 
-    const proofs = bob.proofs([{ can: 'store/add', with: space.did }])
+    const proofs = bob.proofs([{ can: 'store/add', with: space.did() }])
     assert(proofs.length)
   })
 
@@ -104,7 +125,12 @@ describe('Agent', function () {
     })
 
     const space = await agent.createSpace('execute')
-    await agent.setCurrentSpace(space.did)
+    const auth = await space.createAuthorization(agent, {
+      can: '*',
+      expiration: Infinity,
+    })
+    await agent.importSpaceFromDelegation(auth)
+    await agent.setCurrentSpace(space.did())
 
     const { out } = await agent.invokeAndExecute(Space.info, {
       audience: fixtures.service,
@@ -126,7 +152,12 @@ describe('Agent', function () {
     })
 
     const space = await agent.createSpace('execute')
-    await agent.setCurrentSpace(space.did)
+    const auth = await space.createAuthorization(agent, {
+      can: '*',
+      expiration: Infinity,
+    })
+    await agent.importSpaceFromDelegation(auth)
+    await agent.setCurrentSpace(space.did())
 
     const i1 = await agent.invoke(Space.info, {
       audience: fixtures.service,
@@ -179,7 +210,12 @@ describe('Agent', function () {
     })
 
     const space = await agent.createSpace('execute')
-    await agent.setCurrentSpace(space.did)
+    const auth = await space.createAuthorization(agent, {
+      can: '*',
+      expiration: Infinity,
+    })
+    await agent.importSpaceFromDelegation(auth)
+    await agent.setCurrentSpace(space.did())
 
     const out = await agent.getSpaceInfo()
     assert.deepEqual(out, {
@@ -199,7 +235,12 @@ describe('Agent', function () {
     })
 
     const space = await agent.createSpace('execute')
-    await agent.setCurrentSpace(space.did)
+    const auth = await space.createAuthorization(agent, {
+      can: '*',
+      expiration: Infinity,
+    })
+    await agent.importSpaceFromDelegation(auth)
+    await agent.setCurrentSpace(space.did())
 
     const out = await agent.delegate({
       abilities: ['*'],
@@ -229,7 +270,12 @@ describe('Agent', function () {
     })
 
     const space = await alice.createSpace('execute')
-    await alice.setCurrentSpace(space.did)
+    const auth = await space.createAuthorization(alice, {
+      can: '*',
+      expiration: Infinity,
+    })
+    await alice.importSpaceFromDelegation(auth)
+    await alice.setCurrentSpace(space.did())
 
     const delegation = await alice.delegate({
       abilities: ['space/info'],
@@ -238,7 +284,7 @@ describe('Agent', function () {
     })
 
     await bob.importSpaceFromDelegation(delegation)
-    await bob.setCurrentSpace(space.did)
+    await bob.setCurrentSpace(space.did())
 
     // should not be able to store/remove - bob only has ability to space/info
     await assert.rejects(
@@ -286,7 +332,12 @@ describe('Agent', function () {
     })
 
     const space = await alice.createSpace('alice')
-    await alice.setCurrentSpace(space.did)
+    const aliceAuth = await space.createAuthorization(alice, {
+      can: '*',
+      expiration: Infinity,
+    })
+    await alice.importSpaceFromDelegation(aliceAuth)
+    await alice.setCurrentSpace(space.did())
 
     const delegation = await alice.delegate({
       abilities: ['*'],
@@ -309,7 +360,12 @@ describe('Agent', function () {
     )
 
     const bobSpace = await bob.createSpace('bob')
-    await bob.setCurrentSpace(bobSpace.did)
+    const bobAuth = await bobSpace.createAuthorization(bob, {
+      can: '*',
+      expiration: Infinity,
+    })
+    await bob.importSpaceFromDelegation(bobAuth)
+    await bob.setCurrentSpace(bobSpace.did())
     const bobDelegation = await bob.delegate({
       abilities: ['*'],
       audience: fixtures.alice,

--- a/packages/capabilities/src/access.js
+++ b/packages/capabilities/src/access.js
@@ -8,7 +8,7 @@
  *
  * @module
  */
-import { capability, URI, DID, Link, Schema, fail, ok } from '@ucanto/validator'
+import { capability, URI, DID, Schema, fail, ok } from '@ucanto/validator'
 import * as Types from '@ucanto/interface'
 import { equalWith, equal, and, SpaceDID } from './utils.js'
 export { top } from './top.js'
@@ -96,41 +96,6 @@ export const confirm = capability({
       ok({})
     )
   },
-})
-
-/**
- * Issued by trusted authority (usually the one handling invocation) that attest
- * that specific UCAN delegation has been considered authentic.
- *
- * @see https://github.com/web3-storage/specs/blob/main/w3-session.md#authorization-session
- * 
- * @example
- * ```js
- * {
-    iss: "did:web:web3.storage",
-    aud: "did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi",
-    att: [{
-      "with": "did:web:web3.storage",
-      "can": "ucan/attest",
-      "nb": {
-        "proof": {
-          "/": "bafyreifer23oxeyamllbmrfkkyvcqpujevuediffrpvrxmgn736f4fffui"
-        }
-      }
-    }],
-    exp: null
-    sig: "..."
-  }
- * ```
- */
-export const session = capability({
-  can: 'ucan/attest',
-  // Should be web3.storage DID
-  with: URI.match({ protocol: 'did:' }),
-  nb: Schema.struct({
-    // UCAN delegation that is being attested.
-    proof: Link,
-  }),
 })
 
 export const claim = capability({

--- a/packages/capabilities/src/index.js
+++ b/packages/capabilities/src/index.js
@@ -58,7 +58,7 @@ export const abilitiesAsStrings = [
   Store.list.can,
   Access.access.can,
   Access.authorize.can,
-  Access.session.can,
+  UCAN.attest.can,
   Customer.get.can,
   Consumer.has.can,
   Consumer.get.can,

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -92,7 +92,6 @@ export interface DelegationNotFound extends Ucanto.Failure {
   name: 'DelegationNotFound'
 }
 
-export type AccessSession = InferInvokedCapability<typeof AccessCaps.session>
 export type AccessConfirm = InferInvokedCapability<typeof AccessCaps.confirm>
 
 // Provider
@@ -423,6 +422,7 @@ export interface UploadListSuccess extends ListResponse<UploadListItem> {}
 // UCAN core events
 
 export type UCANRevoke = InferInvokedCapability<typeof UCANCaps.revoke>
+export type UCANAttest = InferInvokedCapability<typeof UCANCaps.attest>
 
 export interface Timestamp {
   /**
@@ -536,7 +536,7 @@ export type AbilitiesArray = [
   StoreList['can'],
   Access['can'],
   AccessAuthorize['can'],
-  AccessSession['can'],
+  UCANAttest['can'],
   CustomerGet['can'],
   ConsumerHas['can'],
   ConsumerGet['can'],

--- a/packages/capabilities/src/ucan.js
+++ b/packages/capabilities/src/ucan.js
@@ -73,3 +73,43 @@ export const revoke = capability({
       'nb.proof'
     ),
 })
+
+/**
+ * Issued by trusted authority (usually the one handling invocation) that attest
+ * that specific UCAN delegation has been considered authentic.
+ *
+ * @see https://github.com/web3-storage/specs/blob/main/w3-session.md#authorization-session
+ * 
+ * @example
+ * ```js
+ * {
+    iss: "did:web:web3.storage",
+    aud: "did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi",
+    att: [{
+      "with": "did:web:web3.storage",
+      "can": "ucan/attest",
+      "nb": {
+        "proof": {
+          "/": "bafyreifer23oxeyamllbmrfkkyvcqpujevuediffrpvrxmgn736f4fffui"
+        }
+      }
+    }],
+    exp: null
+    sig: "..."
+  }
+ * ```
+ */
+export const attest = capability({
+  can: 'ucan/attest',
+  // Should be web3.storage DID
+  with: Schema.did(),
+  nb: Schema.struct({
+    // UCAN delegation that is being attested.
+    proof: Schema.link({ version: 1 }),
+  }),
+  derives: (claim, from) =>
+    // With field MUST be the same
+    and(equalWith(claim, from)) ??
+    // UCAN link MUST be the same
+    checkLink(claim.nb.proof, from.nb.proof, 'nb.proof'),
+})

--- a/packages/upload-api/src/access/confirm.js
+++ b/packages/upload-api/src/access/confirm.js
@@ -2,6 +2,7 @@ import * as API from '../types.js'
 import * as Provider from '@ucanto/server'
 import { Absentee, Verifier } from '@ucanto/principal'
 import * as Access from '@web3-storage/capabilities/access'
+import * as UCAN from '@web3-storage/capabilities/ucan'
 import * as delegationsResponse from '../utils/delegations-response.js'
 
 /**
@@ -113,7 +114,7 @@ export async function createSessionProofs({
     proofs: delegationProofs,
   })
 
-  const attestation = await Access.session.delegate({
+  const attestation = await UCAN.attest.delegate({
     issuer: service,
     audience: agent,
     with: service.did(),

--- a/packages/upload-api/src/consumer/has.js
+++ b/packages/upload-api/src/consumer/has.js
@@ -9,7 +9,7 @@ export const provide = (context) =>
   Provider.provide(Consumer.has, (input) => has(input, context))
 
 /**
- * @param {{capability: {with: API.ProviderDID, nb: { consumer: API.DIDKey }}}} input
+ * @param {API.Input<Consumer.has>} input
  * @param {API.ConsumerServiceContext} context
  * @returns {Promise<API.Result<API.ConsumerHasSuccess, API.ConsumerHasFailure>>}
  */

--- a/packages/upload-api/test/helpers/utils.js
+++ b/packages/upload-api/test/helpers/utils.js
@@ -6,7 +6,7 @@ import * as Server from '@ucanto/server'
 import * as Client from '@ucanto/client'
 import * as CAR from '@ucanto/transport/car'
 import * as Context from './context.js'
-import { Access, Provider, Space } from '@web3-storage/capabilities'
+import { Provider, UCAN, Space } from '@web3-storage/capabilities'
 import * as DidMailto from '@web3-storage/did-mailto'
 
 // eslint-disable-next-line unicorn/prefer-export-from
@@ -118,7 +118,7 @@ export const createAuthorization = async ({ account, agent, service }) => {
     expiration: Infinity,
   })
 
-  const attest = await Access.session
+  const attest = await UCAN.attest
     .invoke({
       issuer: service,
       audience: agent,

--- a/packages/upload-api/tsconfig.json
+++ b/packages/upload-api/tsconfig.json
@@ -6,5 +6,5 @@
   },
   "include": ["src", "test"],
   "exclude": ["**/node_modules/**", "dist"],
-  "references": [{ "path": "../capabilities" }]
+  "references": [{ "path": "../capabilities" }, { "path": "../access-client"}]
 }

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -33,6 +33,10 @@ export class Client extends Base {
     }
   }
 
+  did() {
+    return this._agent.did()
+  }
+
   /* c8 ignore start - testing websockets is hard */
   /**
    * Authorize the current agent to use capabilities granted to the passed
@@ -143,13 +147,12 @@ export class Client extends Base {
   }
 
   /**
-   * Create a new space with an optional name.
+   * Create a new space with a given name.
    *
-   * @param {string} [name]
+   * @param {string} name
    */
-  async createSpace(name) {
-    const { did, meta } = await this._agent.createSpace(name)
-    return new Space(did, meta)
+  createSpace(name) {
+    return this._agent.createSpace(name)
   }
 
   /* c8 ignore start - hard to test this without authorize tests which require websockets */
@@ -175,8 +178,7 @@ export class Client extends Base {
    * @param {import('./types.js').Delegation} proof
    */
   async addSpace(proof) {
-    const { did, meta } = await this._agent.importSpaceFromDelegation(proof)
-    return new Space(did, meta)
+    return await this._agent.importSpaceFromDelegation(proof)
   }
 
   /**

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -155,21 +155,21 @@ export class Client extends Base {
     return this._agent.createSpace(name)
   }
 
-  /* c8 ignore start - hard to test this without authorize tests which require websockets */
-  /**
-   * Register the _current_ space with the service.
-   *
-   * @param {string} email
-   * @param {object} [options]
-   * @param {import('./types.js').DID<'web'>} [options.provider]
-   * @param {AbortSignal} [options.signal]
-   */
-  async registerSpace(email, options = {}) {
-    options.provider =
-      options.provider ??
-      /** @type {import('./types.js').DID<'web'>} */ (this.defaultProvider())
-    await this._agent.registerSpace(email, options)
-  }
+  // /* c8 ignore start - hard to test this without authorize tests which require websockets */
+  // /**
+  //  * Register the _current_ space with the service.
+  //  *
+  //  * @param {string} email
+  //  * @param {object} [options]
+  //  * @param {import('./types.js').DID<'web'>} [options.provider]
+  //  * @param {AbortSignal} [options.signal]
+  //  */
+  // async registerSpace(email, options = {}) {
+  //   options.provider =
+  //     options.provider ??
+  //     /** @type {import('./types.js').DID<'web'>} */ (this.defaultProvider())
+  //   await this._agent.registerSpace(email, options)
+  // }
   /* c8 ignore stop */
 
   /**

--- a/packages/w3up-client/test/capability/space.test.js
+++ b/packages/w3up-client/test/capability/space.test.js
@@ -41,7 +41,12 @@ describe('SpaceClient', () => {
         serviceConf: await mockServiceConf(server),
       })
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('test')
+      const auth = await space.createAuthorization(alice, {
+        can: '*',
+        expiration: Infinity,
+      })
+      alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
 
       const info = await alice.capability.space.info(space.did())

--- a/packages/w3up-client/test/capability/store.test.js
+++ b/packages/w3up-client/test/capability/store.test.js
@@ -45,7 +45,12 @@ describe('StoreClient', () => {
         serviceConf: await mockServiceConf(server),
       })
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('test')
+      const auth = await space.createAuthorization(alice, {
+        can: '*',
+        expiration: Infinity,
+      })
+      alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
 
       const car = await randomCAR(128)
@@ -98,7 +103,12 @@ describe('StoreClient', () => {
         serviceConf: await mockServiceConf(server),
       })
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('test')
+      const auth = await space.createAuthorization(alice, {
+        can: '*',
+        expiration: Infinity,
+      })
+      alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
 
       const res = await alice.capability.store.list()
@@ -141,7 +151,12 @@ describe('StoreClient', () => {
         serviceConf: await mockServiceConf(server),
       })
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('test')
+      const auth = await space.createAuthorization(alice, {
+        can: '*',
+        expiration: Infinity,
+      })
+      alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
 
       await alice.capability.store.remove((await randomCAR(128)).cid)

--- a/packages/w3up-client/test/capability/upload.test.js
+++ b/packages/w3up-client/test/capability/upload.test.js
@@ -47,7 +47,12 @@ describe('StoreClient', () => {
         serviceConf: await mockServiceConf(server),
       })
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('test')
+      const auth = await space.createAuthorization(alice, {
+        can: '*',
+        expiration: Infinity,
+      })
+      alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
 
       await alice.capability.upload.add(car.roots[0], [car.cid])
@@ -99,7 +104,12 @@ describe('StoreClient', () => {
         serviceConf: await mockServiceConf(server),
       })
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('test')
+      const auth = await space.createAuthorization(alice, {
+        can: '*',
+        expiration: Infinity,
+      })
+      alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
 
       const res = await alice.capability.upload.list()
@@ -143,7 +153,12 @@ describe('StoreClient', () => {
         serviceConf: await mockServiceConf(server),
       })
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('test')
+      const auth = await space.createAuthorization(alice, {
+        can: '*',
+        expiration: Infinity,
+      })
+      alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
 
       await alice.capability.upload.remove((await randomCAR(128)).roots[0])

--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -75,7 +75,12 @@ describe('Client', () => {
         serviceConf: await mockServiceConf(server),
       })
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('upload-test')
+      const auth = await space.createAuthorization(alice, {
+        can: '*',
+        expiration: Infinity,
+      })
+      alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
 
       const dataCID = await alice.uploadFile(file, {
@@ -165,7 +170,13 @@ describe('Client', () => {
         serviceConf: await mockServiceConf(server),
       })
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('upload-dir-test')
+      const auth = await space.createAuthorization(alice, {
+        can: '*',
+        expiration: Infinity,
+      })
+      await alice.addSpace(auth)
+
       await alice.setCurrentSpace(space.did())
 
       const dataCID = await alice.uploadDirectory(files, {
@@ -242,7 +253,13 @@ describe('Client', () => {
         serviceConf: await mockServiceConf(server),
       })
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('car-space')
+      await alice.addSpace(
+        await space.createAuthorization(alice, {
+          can: '*',
+          expiration: Infinity,
+        })
+      )
       await alice.setCurrentSpace(space.did())
       await alice.uploadCAR(car, {
         onShardStored: (meta) => {
@@ -264,7 +281,13 @@ describe('Client', () => {
       const current0 = alice.currentSpace()
       assert(current0 === undefined)
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('new-space')
+      alice.addSpace(
+        await space.createAuthorization(alice, {
+          can: '*',
+          expiration: Infinity,
+        })
+      )
       await alice.setCurrentSpace(space.did())
 
       const current1 = alice.currentSpace()
@@ -279,6 +302,11 @@ describe('Client', () => {
 
       const name = `space-${Date.now()}`
       const space = await alice.createSpace(name)
+      const auth = await space.createAuthorization(alice, {
+        can: '*',
+        expiration: Infinity,
+      })
+      alice.addSpace(auth)
 
       const spaces = alice.spaces()
       assert.equal(spaces.length, 1)
@@ -290,7 +318,13 @@ describe('Client', () => {
       const alice = new Client(await AgentData.create())
       const bob = new Client(await AgentData.create())
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('new-space')
+      await alice.addSpace(
+        await space.createAuthorization(alice, {
+          can: '*',
+          expiration: Infinity,
+        })
+      )
       await alice.setCurrentSpace(space.did())
 
       const delegation = await alice.createDelegation(bob.agent(), ['*'])
@@ -310,7 +344,13 @@ describe('Client', () => {
       const alice = new Client(await AgentData.create())
       const bob = new Client(await AgentData.create())
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('proof-space')
+      alice.addSpace(
+        await space.createAuthorization(alice, {
+          can: '*',
+          expiration: Infinity,
+        })
+      )
       await alice.setCurrentSpace(space.did())
 
       const delegation = await alice.createDelegation(bob.agent(), ['*'])
@@ -328,7 +368,13 @@ describe('Client', () => {
       const alice = new Client(await AgentData.create())
       const bob = new Client(await AgentData.create())
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('test')
+      await alice.addSpace(
+        await space.createAuthorization(alice, {
+          can: '*',
+          expiration: Infinity,
+        })
+      )
       await alice.setCurrentSpace(space.did())
       const name = `delegation-${Date.now()}`
       const delegation = await alice.createDelegation(bob.agent(), ['*'], {
@@ -383,7 +429,13 @@ describe('Client', () => {
         serviceConf: await mockServiceConf(server),
       })
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('test')
+      await alice.addSpace(
+        await space.createAuthorization(alice, {
+          can: '*',
+          expiration: Infinity,
+        })
+      )
       await alice.setCurrentSpace(space.did())
       const name = `delegation-${Date.now()}`
       const delegation = await alice.createDelegation(bob.agent(), ['*'], {
@@ -398,7 +450,13 @@ describe('Client', () => {
       const alice = new Client(await AgentData.create())
       const bob = new Client(await AgentData.create())
 
-      const space = await alice.createSpace()
+      const space = await alice.createSpace('test')
+      alice.addSpace(
+        await space.createAuthorization(alice, {
+          can: '*',
+          expiration: Infinity,
+        })
+      )
       await alice.setCurrentSpace(space.did())
       const name = `delegation-${Date.now()}`
       const delegation = await alice.createDelegation(bob.agent(), ['*'], {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -48,6 +48,9 @@ importers:
       '@ipld/dag-ucan':
         specifier: ^3.4.0
         version: 3.4.0
+      '@scure/bip39':
+        specifier: ^1.2.1
+        version: 1.2.1
       '@ucanto/client':
         specifier: ^9.0.0
         version: 9.0.0
@@ -2803,6 +2806,17 @@ packages:
   /@protobufjs/utf8@1.1.0:
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  /@scure/base@1.1.3:
+    resolution: {integrity: sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==}
+    dev: false
+
+  /@scure/bip39@1.2.1:
+    resolution: {integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==}
+    dependencies:
+      '@noble/hashes': 1.3.2
+      '@scure/base': 1.1.3
+    dev: false
+
   /@sideway/address@4.1.4:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
     dependencies:
@@ -3317,7 +3331,7 @@ packages:
       '@typescript-eslint/parser': 5.62.0(eslint@8.50.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.50.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.50.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.50.0)(typescript@4.9.5)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.50.0
       graphemer: 1.4.0
@@ -3450,7 +3464,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.50.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.50.0)(typescript@4.9.5)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.50.0
       tsutils: 3.21.0(typescript@5.2.2)
@@ -3506,26 +3520,6 @@ packages:
     dev: true
 
   /@typescript-eslint/utils@5.62.0(eslint@8.50.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.50.0)
-      '@types/json-schema': 7.0.13
-      '@types/semver': 7.5.3
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
-      eslint: 8.50.0
-      eslint-scope: 5.1.1
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/utils@5.62.0(eslint@8.50.0)(typescript@5.2.2):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:


### PR DESCRIPTION
Changes `createSpace` functions so it returns an `OwnSpace` from which one could:

1. Derive mnemonics
2. Create an authorization
3. Setup a recovery with email account