### PR TITLE
feat: access agent proofs method would fail to return some session proofs

### DIFF
--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -106,6 +106,7 @@
       "unicorn/expiring-todo-comments": "off",
       "unicorn/no-array-reduce": "off",
       "unicorn/explicit-length-check": "off",
+      "no-continue": "off",
       "jsdoc/no-undefined-types": [
         "error",
         {

--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -18,7 +18,7 @@
     "lint": "tsc --build && eslint '**/*.{js,ts}' && prettier --check '**/*.{js,ts,yml,json}' --ignore-path ../../.gitignore",
     "build": "tsc --build",
     "check": "tsc --build",
-    "test": "pnpm -r run build && npm run test:node && npm run test:browser",
+    "test": "npm run build && npm run test:node && npm run test:browser",
     "test:node": "mocha 'test/**/!(*.browser).test.js' -n experimental-vm-modules -n no-warnings",
     "test:browser": "playwright-test 'test/**/!(*.node).test.js'",
     "testw": "watch 'pnpm test' src test --interval 1",

--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -18,7 +18,7 @@
     "lint": "tsc --build && eslint '**/*.{js,ts}' && prettier --check '**/*.{js,ts,yml,json}' --ignore-path ../../.gitignore",
     "build": "tsc --build",
     "check": "tsc --build",
-    "test": "npm run build && npm run test:node && npm run test:browser",
+    "test": "pnpm -r run build && npm run test:node && npm run test:browser",
     "test:node": "mocha 'test/**/!(*.browser).test.js' -n experimental-vm-modules -n no-warnings",
     "test:browser": "playwright-test 'test/**/!(*.node).test.js'",
     "testw": "watch 'pnpm test' src test --interval 1",

--- a/packages/access-client/src/agent-data.js
+++ b/packages/access-client/src/agent-data.js
@@ -217,9 +217,6 @@ export function matchSessionProof(ucan, options) {
   const matchesRequiredProof =
     !options.attestedProof ||
     options.attestedProof.toString() === cap.nb.proof.toString()
-  if (!isSessionProof(ucan)) {
-    return false
-  }
   if (isExpiredButNotAllowed) {
     return false
   }

--- a/packages/access-client/src/agent-data.js
+++ b/packages/access-client/src/agent-data.js
@@ -194,36 +194,3 @@ export function getSessionProofs(data, issuer) {
   }
   return proofs
 }
-
-/**
- * Given a UCAN, return whether it is a session proof matching some options
- *
- * @param {Ucanto.Delegation} ucan
- * @param {object} options
- * @param {Ucanto.DID} [options.issuer] - issuer of session proof
- * @param {import('@ucanto/interface').UCANLink} [options.attestedProof] - CID of proof that the session proof attests to
- * @param {boolean} [options.allowExpired]
- * @returns {boolean} whether the ucan matches the options
- */
-export function matchSessionProof(ucan, options) {
-  if (!isSessionProof(ucan)) {
-    return false
-  }
-  const cap = ucan.capabilities[0]
-  const matchesRequiredIssuer =
-    options.issuer === undefined || options.issuer === ucan.issuer.did()
-  const isExpiredButNotAllowed = !options.allowExpired && isExpired(ucan)
-  const matchesRequiredProof =
-    !options.attestedProof ||
-    options.attestedProof.toString() === cap.nb.proof.toString()
-  if (isExpiredButNotAllowed) {
-    return false
-  }
-  if (!matchesRequiredIssuer) {
-    return false
-  }
-  if (!matchesRequiredProof) {
-    return false
-  }
-  return true
-}

--- a/packages/access-client/src/agent-data.js
+++ b/packages/access-client/src/agent-data.js
@@ -171,23 +171,19 @@ export const isSessionProof = (delegation) =>
  * Get a map from CIDs to the session proofs that reference them
  *
  * @param {AgentData} data
- * @param {Ucanto.DID|undefined} [issuer] - if provided, will only return session proofs issued by this id
- * @returns {Record<string, Ucanto.Delegation>}
+ * @returns {Record<string, [Ucanto.Delegation, ...Ucanto.Delegation[]]>}
  */
-export function getSessionProofs(data, issuer) {
-  /** @type {Record<string, Ucanto.Delegation>} */
+export function getSessionProofs(data) {
+  /** @type {Record<string, [Ucanto.Delegation, ...Ucanto.Delegation[]]>} */
   const proofs = {}
   for (const { delegation } of data.delegations.values()) {
-    if (issuer !== undefined && issuer !== delegation.issuer.did()) {
-      // delegation doesn't match issuer
-      continue
-    }
     if (isSessionProof(delegation)) {
       const cap = delegation.capabilities[0]
       if (cap && !isExpired(delegation)) {
         const proof = cap.nb.proof
         if (proof) {
-          proofs[proof.toString()] = delegation
+          proofs[proof.toString()] = proofs[proof.toString()] ?? []
+          proofs[proof.toString()].push(delegation)
         }
       }
     }

--- a/packages/access-client/src/agent-data.js
+++ b/packages/access-client/src/agent-data.js
@@ -171,7 +171,7 @@ export const isSessionProof = (delegation) =>
  * Get a map from CIDs to the session proofs that reference them
  *
  * @param {AgentData} data
- * @param {Ucanto.DID} [issuer] - if provided, will only return session proofs issued by this id
+ * @param {Ucanto.DID|undefined} [issuer] - if provided, will only return session proofs issued by this id
  * @returns {Record<string, Ucanto.Delegation>}
  */
 export function getSessionProofs(data, issuer) {

--- a/packages/access-client/src/agent-data.js
+++ b/packages/access-client/src/agent-data.js
@@ -189,3 +189,26 @@ export function getSessionProofs(data) {
   }
   return proofs
 }
+
+/**
+ * Given a UCAN, return whether it is a session proof matching some options
+ *
+ * @param {Ucanto.Delegation} ucan
+ * @param {object} options
+ * @param {Ucanto.DID} [options.issuer] - issuer of session proof
+ * @param {import('@ucanto/interface').UCANLink} [options.attestedProof] - CID of proof that the session proof attests to
+ * @param {boolean} [options.allowExpired]
+ * @returns {boolean} whether the ucan matches the options
+ */
+export function matchSessionProof(ucan, options) {
+  if ( ! isSessionProof(ucan)) { return false; }
+  const cap = ucan.capabilities[0]
+  const matchesRequiredIssuer = (options.issuer === undefined) || options.issuer === ucan.issuer.did()
+  const isExpiredButNotAllowed = ( ! options.allowExpired) && isExpired(ucan)
+  const matchesRequiredProof = ( ! options.attestedProof) || (options.attestedProof.toString() === cap.nb.proof.toString())
+  if ( ! isSessionProof(ucan)) { return false; }
+  if (isExpiredButNotAllowed) { return false; }
+  if ( ! matchesRequiredIssuer) { return false; }
+  if ( ! matchesRequiredProof) { return false; }
+  return true
+}

--- a/packages/access-client/src/agent-data.js
+++ b/packages/access-client/src/agent-data.js
@@ -180,7 +180,6 @@ export function getSessionProofs(data, issuer) {
   for (const { delegation } of data.delegations.values()) {
     if (issuer !== undefined && issuer !== delegation.issuer.did()) {
       // delegation doesn't match issuer
-      // eslint-disable-next-line no-continue
       continue
     }
     if (isSessionProof(delegation)) {

--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -74,6 +74,9 @@ export async function claimAccess(
  * @param {Ucanto.DID<'web'>} opts.provider - e.g. 'did:web:staging.web3.storage'
  */
 export async function addProvider({ access, space, account, provider }) {
+  console.log('addProvider called. calling invokeAndExecute with', {
+    audience: access.connection.id,
+  })
   const result = await access.invokeAndExecute(Provider.add, {
     audience: access.connection.id,
     with: account.did(),

--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -74,9 +74,6 @@ export async function claimAccess(
  * @param {Ucanto.DID<'web'>} opts.provider - e.g. 'did:web:staging.web3.storage'
  */
 export async function addProvider({ access, space, account, provider }) {
-  console.log('addProvider called. calling invokeAndExecute with', {
-    audience: access.connection.id,
-  })
   const result = await access.invokeAndExecute(Provider.add, {
     audience: access.connection.id,
     with: account.did(),

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -175,25 +175,21 @@ export class Agent {
     /** @type {Array<{ delegation: Ucanto.Delegation, meta: import('./types.js').DelegationMeta }>} */
     const values = []
     for (const [, value] of this.#data.delegations) {
-      // check expiration
-      if (isExpired(value.delegation)) {
-        continue
-      }
-      if (isTooEarly(value.delegation)) {
-        continue
-      }
-
-      if (Array.isArray(caps) && caps.length > 0) {
-        // caps param is provided. Ensure that the delegations we're looping over can delegate to these caps
-        for (const cap of _caps) {
-          if (canDelegateCapability(value.delegation, cap)) {
-            values.push(value)
-            _caps.delete(cap)
+      if (
+        !isExpired(value.delegation) && // check if delegation can be used
+        !isTooEarly(value.delegation)
+      ) {
+        // check if we need to filter for caps
+        if (Array.isArray(caps) && caps.length > 0) {
+          for (const cap of _caps) {
+            if (canDelegateCapability(value.delegation, cap)) {
+              _caps.delete(cap)
+              values.push(value)
+            }
           }
+        } else {
+          values.push(value)
         }
-      } else {
-        // no caps param is provided. Caller must want all delegations.
-        values.push(value)
       }
     }
     return values

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -264,7 +264,9 @@ export class Agent {
 
     const sessions = getSessionProofs(this.#data)
     for (const proof of arr) {
-      const sessionProofs = sessions[proof.asCID.toString()]
+      const sessionProofs = Object.values(
+        sessions[proof.asCID.toString()] ?? {}
+      ).flat()
       if (sessionProofs) {
         arr.push(...sessionProofs)
       }

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -175,6 +175,7 @@ export class Agent {
     /** @type {Array<{ delegation: Ucanto.Delegation, meta: import('./types.js').DelegationMeta }>} */
     const values = []
     for (const [, value] of this.#data.delegations) {
+      // check expiration
       if (
         !isExpired(value.delegation) && // check if delegation can be used
         !isTooEarly(value.delegation)

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -254,8 +254,8 @@ export class Agent {
    * Proof of session will also be included in the returned proofs if any
    * proofs matching the passed capabilities require it.
    *
-   * @param {import('@ucanto/interface').Capability[]} [caps] - Capabilities to filter by. Empty or undefined caps with return all the proofs.
-   * @param {Ucanto.DID} [invocationAudience] - audience of invocation these proofs will be bundled with.
+   * @param {import('@ucanto/interface').Capability[]|undefined} [caps] - Capabilities to filter by. Empty or undefined caps with return all the proofs.
+   * @param {Ucanto.DID|undefined} [invocationAudience] - audience of invocation these proofs will be bundled with.
    */
   proofs(caps, invocationAudience) {
     const arr = []

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -183,7 +183,6 @@ export class Agent {
         if (Array.isArray(caps) && caps.length > 0) {
           for (const cap of _caps) {
             if (canDelegateCapability(value.delegation, cap)) {
-              _caps.delete(cap)
               values.push(value)
             }
           }

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-continue */
 /* eslint-disable max-depth */
 import * as Client from '@ucanto/client'
 // @ts-ignore
@@ -255,9 +254,11 @@ export class Agent {
    * proofs matching the passed capabilities require it.
    *
    * @param {import('@ucanto/interface').Capability[]|undefined} [caps] - Capabilities to filter by. Empty or undefined caps with return all the proofs.
-   * @param {Ucanto.DID|undefined} [invocationAudience] - audience of invocation these proofs will be bundled with.
+   * @param {object} [options] - options
+   * @param {Ucanto.DID|undefined} [options.sessionProofIssuer] - When proofs require ucan/attest session proofs, filter them to this issuer.
+   * e.g. use this if you are calling this to get proofs to build a UCAN invocation that will rely on session proofs issued by the invocation audience
    */
-  proofs(caps, invocationAudience) {
+  proofs(caps, options = {}) {
     const arr = []
     for (const { delegation } of this.#delegations(caps)) {
       if (delegation.audience.did() === this.issuer.did()) {
@@ -265,7 +266,7 @@ export class Agent {
       }
     }
 
-    const sessions = getSessionProofs(this.#data, invocationAudience)
+    const sessions = getSessionProofs(this.#data, options.sessionProofIssuer)
     for (const proof of arr) {
       const session = sessions[proof.asCID.toString()]
       if (session) {
@@ -580,7 +581,7 @@ export class Agent {
             can: cap.can,
           },
         ],
-        audience.did()
+        { sessionProofIssuer: audience.did() }
       ),
     ]
 

--- a/packages/access-client/test/agent-data.test.js
+++ b/packages/access-client/test/agent-data.test.js
@@ -1,5 +1,10 @@
 import assert from 'assert'
-import { AgentData } from '../src/agent-data.js'
+import { AgentData, getSessionProofs } from '../src/agent-data.js'
+import * as ed25519 from '@ucanto/principal/ed25519'
+import { Access } from '@web3-storage/capabilities'
+import { Absentee } from '@ucanto/principal'
+import * as DidMailto from '@web3-storage/did-mailto'
+import * as ucanto from '@ucanto/core'
 
 describe('AgentData', () => {
   it('should not destructure store methods', async () => {
@@ -22,5 +27,56 @@ describe('AgentData', () => {
     const store = new Store()
     const data = await AgentData.create(undefined, { store })
     await assert.doesNotReject(data.setCurrentSpace('did:key:y'))
+  })
+
+  it('when there are several session proofs with same nb.proof, ensure both are returned', async () => {
+    const agent = await ed25519.Signer.generate()
+    const account = DidMailto.fromEmail(
+      `test-${Math.random().toString().slice(2)}@dag.house`
+    )
+    const agentData = await AgentData.create()
+    const serviceA = await ed25519.Signer.generate()
+    const serviceAWeb = serviceA.withDID('did:web:a.up.web3.storage')
+    const serviceB = await ed25519.Signer.generate()
+    const serviceBWeb = serviceB.withDID('did:web:b.up.web3.storage')
+    const services = [serviceAWeb, serviceBWeb]
+
+    // note: this delegation has same CID in all loops since nothing service-specific is in the delegation
+    const delegation = await ucanto.delegate({
+      issuer: Absentee.from({ id: account }),
+      audience: agent,
+      capabilities: [
+        {
+          can: 'provider/add',
+          with: 'ucan:*',
+        },
+      ],
+    })
+    agentData.addDelegation(delegation)
+
+    for (const service of services) {
+      const session = await Access.session.delegate({
+        issuer: service,
+        audience: agent,
+        with: service.did(),
+        nb: { proof: delegation.cid },
+      })
+      agentData.addDelegation(session)
+    }
+
+    const gotSessions = getSessionProofs(agentData)
+    assert.ok(
+      delegation.cid.toString() in gotSessions,
+      'sessions map has entry for delegation cid'
+    )
+    assert.ok(
+      Array.isArray(gotSessions[delegation.cid.toString()]),
+      'values of session map are Arrays'
+    )
+    assert.equal(
+      gotSessions[delegation.cid.toString()].length,
+      services.length,
+      'sessions map has all session proofs even when there are multiple with same .nb.proof cid'
+    )
   })
 })

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -1,4 +1,6 @@
+/* eslint-disable no-unused-vars */
 import assert from 'assert'
+import * as ucanto from '@ucanto/core'
 import { URI } from '@ucanto/validator'
 import { Delegation, provide } from '@ucanto/server'
 import { Agent, connection } from '../src/agent.js'
@@ -6,6 +8,10 @@ import * as Space from '@web3-storage/capabilities/space'
 import * as UCAN from '@web3-storage/capabilities/ucan'
 import { createServer } from './helpers/utils.js'
 import * as fixtures from './helpers/fixtures.js'
+import * as ed25519 from '@ucanto/principal/ed25519'
+import { Access } from '@web3-storage/capabilities'
+import { Absentee } from '@ucanto/principal'
+import * as DidMailto from '@web3-storage/did-mailto'
 
 describe('Agent', function () {
   it('should return did', async function () {
@@ -334,5 +340,60 @@ describe('Agent', function () {
       result4.ok,
       `failed to revoke even though proof was passed: ${result4.error?.message}`
     )
+  })
+
+  /**
+   * An agent may manage a bunch of different proofs for the same agent key. e.g. proofs may authorize agent key to access various audiences or sessions on those audiences.
+   * When one of the proofs is a session proof issued by w3upA or w3upB, the Agent#proofs result should contain proofs appropriate for the session host.
+   */
+  it('should include session proof based on connection', async () => {
+    // const space = await ed25519.Signer.generate()
+    const account = DidMailto.fromEmail(`test-${Math.random().toString().slice(2)}@dag.house`)
+    const serviceA = await ed25519.Signer.generate()
+    const serviceAWeb = serviceA.withDID('did:web:a.up.web3.storage')
+    const serviceB = await ed25519.Signer.generate()
+    const serviceBWeb = serviceB.withDID('did:web:b.up.web3.storage')
+
+    const server = createServer()
+    const agent = await Agent.create(undefined, {
+      connection: connection({ channel: server }),
+    })
+
+    // the agent has a delegation+sesssion for each service
+    const services = [serviceAWeb, serviceBWeb]
+    for (const service of services) {
+      const delegation = await ucanto.delegate({
+        issuer: Absentee.from({ id: account }),
+        audience: agent,
+        capabilities: [
+          {
+            can: 'provider/add',
+            with: 'ucan:*',
+          }
+        ]
+      })
+      const session = await Access.session.delegate({
+        issuer: service,
+        audience: agent,
+        with: service.did(),
+        nb: { proof: delegation.cid },
+      })
+      agent.addProof(delegation)
+      agent.addProof(session)
+    }
+
+    // now let's say we want to send provider/add invocation to serviceB
+    const desiredInvocationAudience = serviceAWeb
+    const proofsA = agent.proofs(
+      [
+        {
+          can: 'provider/add',
+          with: account
+        }
+      ],
+      desiredInvocationAudience.did(),
+    )
+    assert.ok(proofsA)
+    assert.equal(proofsA[1].issuer.did(), desiredInvocationAudience.did())
   })
 })

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -390,13 +390,11 @@ describe('Agent', function () {
       agent.addProof(delegation)
       agent.addProof(session)
     }
-
+    const proofsForService = agent.proofs([
+      { can: 'provider/add', with: account },
+    ])
+    assert.ok(proofsForService, 'proofs returned some proofs')
     for (const service of [serviceAWeb, serviceBWeb]) {
-      const proofsForService = agent.proofs(
-        [{ can: 'provider/add', with: account }],
-        { sessionProofIssuer: service.did() }
-      )
-      assert.ok(proofsForService, 'proofs returned some proofs')
       assert.ok(
         proofsForService.find((proof) => {
           if (!proof.capabilities.some((cap) => cap.can === 'ucan/attest')) {
@@ -467,15 +465,12 @@ describe('Agent', function () {
       }),
     })
 
-    const proofsB = agentConnectedToServiceB.proofs(
-      [
-        {
-          can: 'provider/add',
-          with: account,
-        },
-      ],
-      { sessionProofIssuer: serviceBWeb.did() }
-    )
+    const proofsB = agentConnectedToServiceB.proofs([
+      {
+        can: 'provider/add',
+        with: account,
+      },
+    ])
     assert.ok(proofsB)
     assert.ok(
       proofsB.find((proof) => {

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -405,7 +405,7 @@ describe('Agent', function () {
     assert.equal(proofsA[1].issuer.did(), serviceAWeb.did())
 
     /**
-     * now let's consider a new Agent that reuses the AgentData for the first agent. e.g. in the case of a long running db of AgentData but a transient Agent that exists only for a bit to access/use the data.
+     * now let's consider a new Agent that reuses the AgentData for the first agent. e.g. in the common case of an Agent being instantiated with an pre-existing AgentData.
      * Unlike the first agentA which made connections to serviceA, this agentB has a connection to serviceB. But all these Agents reuse an underlying AgentData with proofs for everyone.
      * That Agent should be able to call proofs to get proofs incl. sessionProofs issued by that invo
      */
@@ -443,17 +443,22 @@ describe('Agent', function () {
       )
       const serviceBWebSessionProofInProviderAddInvocationForServiceBWeb =
         providerAddInvocation.proofs.find((proof) => {
-          // @ts-expect-error complicated ucanto
+          if (!('capabilities' in proof)) {
+            return false
+          }
           const isSessionProof = proof.capabilities.some(
-            (/** @type {any} */ cap) => cap.can === 'ucan/attest'
+            (cap) => cap.can === 'ucan/attest'
           )
-          // @ts-expect-error complicated ucanto
           const isIssuedByServiceBWeb = proof.issuer.did() === serviceBWeb.did()
           return isSessionProof && isIssuedByServiceBWeb
         })
       assert.ok(serviceBWebSessionProofInProviderAddInvocationForServiceBWeb)
+      assert.ok(
+        'issuer' in
+          serviceBWebSessionProofInProviderAddInvocationForServiceBWeb,
+        'session proof on invocation is a delegation and not just a link'
+      )
       assert.equal(
-        // @ts-expect-error comoplicated ucanto type
         serviceBWebSessionProofInProviderAddInvocationForServiceBWeb.issuer.did(),
         serviceBWeb.did(),
         'agent invoke method built an invocation containing the session proof issued by the right invocation audience'

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -11,7 +11,6 @@ import * as ed25519 from '@ucanto/principal/ed25519'
 import { Access, Provider } from '@web3-storage/capabilities'
 import { Absentee } from '@ucanto/principal'
 import * as DidMailto from '@web3-storage/did-mailto'
-import { isSessionProof } from '../src/agent-data.js'
 
 describe('Agent', function () {
   it('should return did', async function () {
@@ -446,7 +445,7 @@ describe('Agent', function () {
         providerAddInvocation.proofs.find((proof) => {
           // @ts-expect-error complicated ucanto
           const isSessionProof = proof.capabilities.some(
-            (cap) => cap.can === 'ucan/attest'
+            (/** @type {any} */ cap) => cap.can === 'ucan/attest'
           )
           // @ts-expect-error complicated ucanto
           const isIssuedByServiceBWeb = proof.issuer.did() === serviceBWeb.did()

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -348,7 +348,9 @@ describe('Agent', function () {
    */
   it('should include session proof based on connection', async () => {
     // const space = await ed25519.Signer.generate()
-    const account = DidMailto.fromEmail(`test-${Math.random().toString().slice(2)}@dag.house`)
+    const account = DidMailto.fromEmail(
+      `test-${Math.random().toString().slice(2)}@dag.house`
+    )
     const serviceA = await ed25519.Signer.generate()
     const serviceAWeb = serviceA.withDID('did:web:a.up.web3.storage')
     const serviceB = await ed25519.Signer.generate()
@@ -369,8 +371,8 @@ describe('Agent', function () {
           {
             can: 'provider/add',
             with: 'ucan:*',
-          }
-        ]
+          },
+        ],
       })
       const session = await Access.session.delegate({
         issuer: service,
@@ -388,12 +390,14 @@ describe('Agent', function () {
       [
         {
           can: 'provider/add',
-          with: account
-        }
+          with: account,
+        },
       ],
-      desiredInvocationAudience.did(),
+      desiredInvocationAudience.did()
     )
     assert.ok(proofsA)
     assert.equal(proofsA[1].issuer.did(), desiredInvocationAudience.did())
+
+    // TODO(bengo): Show that the proofs vary based on agent.connection.id (like w3cli does)
   })
 })

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -380,6 +380,11 @@ describe('Agent', function () {
             with: 'ucan:*',
           },
         ],
+        // facts: [
+        //   {
+        //     service: service.did(),
+        //   },
+        // ],
       })
       const session = await Access.session.delegate({
         issuer: service,
@@ -402,7 +407,18 @@ describe('Agent', function () {
       { sessionProofIssuer: serviceAWeb.did() }
     )
     assert.ok(proofsA)
-    assert.equal(proofsA[1].issuer.did(), serviceAWeb.did())
+    assert.ok(
+      proofsA.find((proof) => {
+        if (!proof.capabilities.some((cap) => cap.can === 'ucan/attest')) {
+          return false
+        }
+        if (proof.issuer.did() !== serviceAWeb.did()) {
+          return false
+        }
+        return true
+      }),
+      'proofs returns a session proof signed by serviceAWeb'
+    )
 
     /**
      * now let's consider a new Agent that reuses the AgentData for the first agent. e.g. in the common case of an Agent being instantiated with an pre-existing AgentData.
@@ -427,7 +443,18 @@ describe('Agent', function () {
         { sessionProofIssuer: serviceBWeb.did() }
       )
       assert.ok(proofsB)
-      assert.equal(proofsB[1].issuer.did(), serviceBWeb.did())
+      assert.ok(
+        proofsB.find((proof) => {
+          if (!proof.capabilities.some((cap) => cap.can === 'ucan/attest')) {
+            return false
+          }
+          if (proof.issuer.did() !== serviceBWeb.did()) {
+            return false
+          }
+          return true
+        }),
+        'proofs returns a session proof signed by serviceBWeb'
+      )
 
       const providerAddInvocation = await agentConnectedToServiceB.invoke(
         // @ts-expect-error - complaint about options.nb.provider not matching a did:mailto type, but it is. Seems like ucanto error with complex types.

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import assert from 'assert'
 import * as ucanto from '@ucanto/core'
 import { URI } from '@ucanto/validator'

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -399,7 +399,7 @@ describe('Agent', function () {
           with: account,
         },
       ],
-      desiredInvocationAudience.did()
+      { sessionProofIssuer: desiredInvocationAudience.did() }
     )
     assert.ok(proofsA)
     assert.equal(proofsA[1].issuer.did(), desiredInvocationAudience.did())

--- a/packages/upload-api/src/access/confirm.js
+++ b/packages/upload-api/src/access/confirm.js
@@ -107,6 +107,9 @@ export async function createSessionProofs({
   expiration = Infinity,
   accessConfirmInvocation,
 }) {
+  // if accessConfirmInvocation was provided, we'll create both proofs with facts about the access/confirm invocation that led to them.
+  const accessConfirmInvocationFacts = accessConfirmInvocation ? [{ cause: accessConfirmInvocation }] : []
+
   // create an delegation on behalf of the account with an absent signature.
   const delegation = await Provider.delegate({
     issuer: Absentee.from({ id: account.did() }),
@@ -115,7 +118,7 @@ export async function createSessionProofs({
     expiration,
     proofs: delegationProofs,
     facts: [
-      ...(accessConfirmInvocation ?[{ cause: accessConfirmInvocation }] : []),
+      ...accessConfirmInvocationFacts,
     ],
   })
 
@@ -125,6 +128,9 @@ export async function createSessionProofs({
     with: service.did(),
     nb: { proof: delegation.cid },
     expiration,
+    facts: [
+      ...accessConfirmInvocationFacts,
+    ]
   })
 
   return [delegation, attestation]

--- a/packages/upload-api/src/access/confirm.js
+++ b/packages/upload-api/src/access/confirm.js
@@ -111,6 +111,11 @@ export async function createSessionProofs({
     capabilities,
     expiration,
     proofs: delegationProofs,
+    facts: [
+      {
+        service: service.did(),
+      }
+    ]
   })
 
   const attestation = await Access.session.delegate({

--- a/packages/upload-api/src/access/confirm.js
+++ b/packages/upload-api/src/access/confirm.js
@@ -68,6 +68,12 @@ export async function confirm({ capability, invocation }, ctx) {
     // implement sudo access anyway.
     delegationProofs: delegationsResult.ok,
     expiration: Infinity,
+    attestationFacts: [
+      {
+        // include this so that the attestation CID is unique across confirmations
+        cause: invocation.cid,
+      }
+    ]
   })
 
   // Store the delegations so that they can be pulled with access/claim.
@@ -92,6 +98,7 @@ export async function confirm({ capability, invocation }, ctx) {
  * @param {API.Capabilities} opts.capabilities
  * @param {API.Delegation[]} opts.delegationProofs
  * @param {number} opts.expiration
+ * @param {import('@ipld/dag-ucan').Fact[]} [opts.attestationFacts]
  * @returns {Promise<[delegation: API.Delegation, attestation: API.Delegation]>}
  */
 export async function createSessionProofs({
@@ -103,6 +110,7 @@ export async function createSessionProofs({
   // default to Infinity is reasonable here because
   // account consented to this.
   expiration = Infinity,
+  attestationFacts,
 }) {
   // create an delegation on behalf of the account with an absent signature.
   const delegation = await Provider.delegate({
@@ -111,11 +119,7 @@ export async function createSessionProofs({
     capabilities,
     expiration,
     proofs: delegationProofs,
-    facts: [
-      {
-        service: service.did(),
-      }
-    ]
+    facts: attestationFacts,
   })
 
   const attestation = await Access.session.delegate({

--- a/packages/upload-api/src/access/confirm.js
+++ b/packages/upload-api/src/access/confirm.js
@@ -68,12 +68,7 @@ export async function confirm({ capability, invocation }, ctx) {
     // implement sudo access anyway.
     delegationProofs: delegationsResult.ok,
     expiration: Infinity,
-    attestationFacts: [
-      {
-        // include this so that the attestation CID is unique across confirmations
-        cause: invocation.cid,
-      }
-    ]
+    accessConfirmInvocation: invocation.cid,
   })
 
   // Store the delegations so that they can be pulled with access/claim.
@@ -98,7 +93,7 @@ export async function confirm({ capability, invocation }, ctx) {
  * @param {API.Capabilities} opts.capabilities
  * @param {API.Delegation[]} opts.delegationProofs
  * @param {number} opts.expiration
- * @param {import('@ipld/dag-ucan').Fact[]} [opts.attestationFacts]
+ * @param {import('@ucanto/interface').UCANLink} [opts.accessConfirmInvocation] - link to invocation of access/confirm that confirmed the issuance of these session proofs
  * @returns {Promise<[delegation: API.Delegation, attestation: API.Delegation]>}
  */
 export async function createSessionProofs({
@@ -110,7 +105,7 @@ export async function createSessionProofs({
   // default to Infinity is reasonable here because
   // account consented to this.
   expiration = Infinity,
-  attestationFacts,
+  accessConfirmInvocation,
 }) {
   // create an delegation on behalf of the account with an absent signature.
   const delegation = await Provider.delegate({
@@ -119,7 +114,9 @@ export async function createSessionProofs({
     capabilities,
     expiration,
     proofs: delegationProofs,
-    facts: attestationFacts,
+    facts: [
+      ...(accessConfirmInvocation ?[{ cause: accessConfirmInvocation }] : []),
+    ],
   })
 
   const attestation = await Access.session.delegate({


### PR DESCRIPTION
Motivation:
* fix w3cli bug I witnessed in my local setup https://github.com/web3-storage/w3cli/issues/113

Context
* Why does this fix it?
  * previously, it was possible for calls to `Agent#registerSpace` to fail due to invalid proofs, even if the underlying AgentData had the right proof. This was because `registerSpace` ends up calling `invokeAndExecute(Provider.add)`, which calls `invoke` to build the invocation, which calls `proofs` to get the proofs for the invocation. And `proofs` could fail to include a sessionProof that was appropriate for the invocation audience of the invocation built by `Agent#invoke`. Now, `Agent#proofs` returns all the sessionProofs that might be relevant.
* explanation of underlying cause of that w3cli issue 113 https://github.com/web3-storage/w3up/pull/1047#discussion_r1377918605