### PR TITLE
feat!: add storefront filecoin api to upload api

### DIFF
--- a/.github/workflows/upload-api.yml
+++ b/.github/workflows/upload-api.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Prepare
         run: pnpm install
 
+      - name: Build
+        run: |
+          pnpm install
+          pnpm run --if-present build
+
       - name: Check
         uses: gozala/typescript-error-reporter-action@v1.0.8
         with:

--- a/packages/filecoin-api/test/context/queue-implementations.js
+++ b/packages/filecoin-api/test/context/queue-implementations.js
@@ -1,0 +1,32 @@
+import { Queue } from './queue.js'
+
+/**
+ * @param {Map<string, unknown[]>} queuedMessages 
+ */
+export const getQueueImplementations = (
+  queuedMessages,
+  QueueImplementation = Queue
+) => {
+  queuedMessages.set('filecoinSubmitQueue', [])
+  queuedMessages.set('pieceOfferQueue', [])
+  const filecoinSubmitQueue = new QueueImplementation({
+    onMessage: (message) => {
+      const messages = queuedMessages.get('filecoinSubmitQueue') || []
+      messages.push(message)
+      queuedMessages.set('filecoinSubmitQueue', messages)
+    },
+  })
+  const pieceOfferQueue = new QueueImplementation({
+    onMessage: (message) => {
+      const messages = queuedMessages.get('pieceOfferQueue') || []
+      messages.push(message)
+      queuedMessages.set('pieceOfferQueue', messages)
+    },
+  })
+  return {
+    storefront: {
+      filecoinSubmitQueue,
+      pieceOfferQueue
+    }
+  }
+}

--- a/packages/filecoin-api/test/context/service.js
+++ b/packages/filecoin-api/test/context/service.js
@@ -13,6 +13,9 @@ import * as API from '../../src/types.js'
 import { validateAuthorization } from '../utils.js'
 import { mockService } from './mocks.js'
 
+export { getStoreImplementations } from './store-implementations.js'
+export { getQueueImplementations } from './queue-implementations.js'
+
 /**
  * Mocked w3filecoin services
  */

--- a/packages/filecoin-api/test/storefront.spec.js
+++ b/packages/filecoin-api/test/storefront.spec.js
@@ -5,9 +5,7 @@ import * as Signer from '@ucanto/principal/ed25519'
 import * as StorefrontService from './services/storefront.js'
 import * as StorefrontEvents from './events/storefront.js'
 
-import { getStoreImplementations } from './context/store-implementations.js'
-import { Queue } from './context/queue.js'
-import { getMockService, getConnection } from './context/service.js'
+import { getMockService, getConnection, getStoreImplementations, getQueueImplementations } from './context/service.js'
 import { validateAuthorization } from './utils.js'
 
 describe('storefront', () => {
@@ -26,22 +24,9 @@ describe('storefront', () => {
         // resources
         /** @type {Map<string, unknown[]>} */
         const queuedMessages = new Map()
-        queuedMessages.set('filecoinSubmitQueue', [])
-        queuedMessages.set('pieceOfferQueue', [])
-        const filecoinSubmitQueue = new Queue({
-          onMessage: (message) => {
-            const messages = queuedMessages.get('filecoinSubmitQueue') || []
-            messages.push(message)
-            queuedMessages.set('filecoinSubmitQueue', messages)
-          },
-        })
-        const pieceOfferQueue = new Queue({
-          onMessage: (message) => {
-            const messages = queuedMessages.get('pieceOfferQueue') || []
-            messages.push(message)
-            queuedMessages.set('pieceOfferQueue', messages)
-          },
-        })
+        const {
+          storefront: { filecoinSubmitQueue, pieceOfferQueue }
+        } = getQueueImplementations(queuedMessages)
         const {
           storefront: { pieceStore, receiptStore, taskStore },
         } = getStoreImplementations()

--- a/packages/upload-api/package.json
+++ b/packages/upload-api/package.json
@@ -110,6 +110,7 @@
     "@web3-storage/access": "workspace:^",
     "@web3-storage/capabilities": "workspace:^",
     "@web3-storage/did-mailto": "workspace:^",
+    "@web3-storage/filecoin-api": "workspace:^",
     "multiformats": "^12.1.2",
     "p-retry": "^5.1.2"
   },

--- a/packages/upload-api/src/lib.js
+++ b/packages/upload-api/src/lib.js
@@ -17,6 +17,7 @@ import { createService as createAdminService } from './admin.js'
 import { createService as createRateLimitService } from './rate-limit.js'
 import { createService as createUcanService } from './ucan.js'
 import { createService as createPlanService } from './plan.js'
+import { createService as createFilecoinService } from '@web3-storage/filecoin-api/storefront/service'
 
 export * from './types.js'
 
@@ -28,7 +29,10 @@ export const createServer = ({ id, codec = Legacy.inbound, ...context }) =>
     ...createRevocationChecker(context),
     id,
     codec,
-    service: createService(context),
+    service: createService({
+      ...context,
+      id
+    }),
     catch: (error) => context.errorReporter.catch(error),
   })
 
@@ -50,6 +54,7 @@ export const createService = (context) => ({
   upload: createUploadService(context),
   ucan: createUcanService(context),
   plan: createPlanService(context),
+  filecoin: createFilecoinService(context).filecoin,
 })
 
 /**

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -19,6 +19,8 @@ import type {
 import type { ProviderInput, ConnectionView } from '@ucanto/server'
 
 import { Signer as EdSigner } from '@ucanto/principal/ed25519'
+import { StorefrontService } from '@web3-storage/filecoin-api/types'
+import { ServiceContext as FilecoinServiceContext } from '@web3-storage/filecoin-api/storefront/api'
 import { DelegationsStorage as Delegations } from './types/delegations.js'
 import { ProvisionsStorage as Provisions } from './types/provisions.js'
 import { RateLimitsStorage as RateLimits } from './types/rate-limits.js'
@@ -145,7 +147,7 @@ export type { RateLimitsStorage, RateLimit } from './types/rate-limits.js'
 import { PlansStorage } from './types/plans.js'
 export type { PlansStorage } from './types/plans.js'
 
-export interface Service {
+export interface Service extends StorefrontService {
   store: {
     add: ServiceMethod<StoreAdd, StoreAddSuccess, Failure>
     get: ServiceMethod<StoreGet, StoreGetSuccess, StoreGetFailure>
@@ -328,7 +330,8 @@ export interface ServiceContext
     RateLimitServiceContext,
     RevocationServiceContext,
     PlanServiceContext,
-    UploadServiceContext {}
+    UploadServiceContext,
+    FilecoinServiceContext {}
 
 export interface UcantoServerContext extends ServiceContext, RevocationChecker {
   id: Signer

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -364,6 +364,9 @@ importers:
       '@web3-storage/did-mailto':
         specifier: workspace:^
         version: link:../did-mailto
+      '@web3-storage/filecoin-api':
+        specifier: workspace:^
+        version: link:../filecoin-api
       multiformats:
         specifier: ^12.1.2
         version: 12.1.2
@@ -3317,7 +3320,7 @@ packages:
       '@typescript-eslint/parser': 5.62.0(eslint@8.50.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.50.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.50.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.50.0)(typescript@5.2.2)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.50.0
       graphemer: 1.4.0
@@ -3450,7 +3453,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.50.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.50.0)(typescript@5.2.2)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.50.0
       tsutils: 3.21.0(typescript@5.2.2)
@@ -3506,6 +3509,26 @@ packages:
     dev: true
 
   /@typescript-eslint/utils@5.62.0(eslint@8.50.0)(typescript@4.9.5):
+    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.50.0)
+      '@types/json-schema': 7.0.13
+      '@types/semver': 7.5.3
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
+      eslint: 8.50.0
+      eslint-scope: 5.1.1
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils@5.62.0(eslint@8.50.0)(typescript@5.2.2):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:


### PR DESCRIPTION
Adds `filecoin/*` to the `upload-api`, so that web3.storage implements storefront capabilities

This will enable us to integrate the new API with w3infra, so that clients can execute `filecoin/offer` to web3.storage.