### PR TITLE
fix: trigger commit for release of w3up client

### DIFF
--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -31,6 +31,7 @@ describe('Client', () => {
             const invCap = invocation.capabilities[0]
             assert.equal(invCap.can, StoreCapabilities.add.can)
             assert.equal(invCap.with, alice.currentSpace()?.did())
+
             return {
               ok: {
                 status: 'upload',


### PR DESCRIPTION
This was previously released with old version of `upload-client`, so still using old PieceCIDv2 🤦🏼 

see https://github.com/web3-storage/w3up/pull/1011/files#diff-25fd91ace9b7aae0918c2010deea96d0cf07d0e7407973e2dc54efbc326d6dd4R7