### PR TITLE
fix: enable storefront signer to be different from main service signer

### DIFF
--- a/packages/filecoin-api/src/storefront/api.ts
+++ b/packages/filecoin-api/src/storefront/api.ts
@@ -35,7 +35,7 @@ export interface ServiceContext {
   /**
    * Service signer
    */
-  id: Signer
+  storefrontSigner: Signer
   /**
    * Principal for aggregator service
    */
@@ -86,7 +86,7 @@ export interface StorefrontClientContext {
 export interface CronContext
   extends Pick<
     ServiceContext,
-    'id' | 'pieceStore' | 'receiptStore' | 'taskStore' | 'aggregatorId'
+    'storefrontSigner' | 'pieceStore' | 'receiptStore' | 'taskStore' | 'aggregatorId'
   > {}
 
 export interface PieceRecord {

--- a/packages/filecoin-api/src/storefront/events.js
+++ b/packages/filecoin-api/src/storefront/events.js
@@ -140,7 +140,7 @@ export const handleCronTick = async (context) => {
   const updatedResponses = await Promise.all(
     submittedPieces.ok.map((pieceRecord) =>
       updatePiecesWithDeal({
-        id: context.id,
+        id: context.storefrontSigner,
         aggregatorId: context.aggregatorId,
         pieceRecord,
         pieceStore: context.pieceStore,

--- a/packages/filecoin-api/src/storefront/service.js
+++ b/packages/filecoin-api/src/storefront/service.js
@@ -26,7 +26,7 @@ export const filecoinOffer = async ({ capability }, context) => {
       return { error: new StoreOperationFailed(hasRes.error.message) }
     }
 
-    const group = context.id.did()
+    const group = context.storefrontSigner.did()
     if (!hasRes.ok) {
       // Queue the piece for validation etc.
       const queueRes = await context.filecoinSubmitQueue.add({
@@ -46,9 +46,9 @@ export const filecoinOffer = async ({ capability }, context) => {
   const [submitfx, acceptfx] = await Promise.all([
     StorefrontCaps.filecoinSubmit
       .invoke({
-        issuer: context.id,
-        audience: context.id,
-        with: context.id.did(),
+        issuer: context.storefrontSigner,
+        audience: context.storefrontSigner,
+        with: context.storefrontSigner.did(),
         nb: {
           piece,
           content,
@@ -58,9 +58,9 @@ export const filecoinOffer = async ({ capability }, context) => {
       .delegate(),
     StorefrontCaps.filecoinAccept
       .invoke({
-        issuer: context.id,
-        audience: context.id,
-        with: context.id.did(),
+        issuer: context.storefrontSigner,
+        audience: context.storefrontSigner,
+        with: context.storefrontSigner.did(),
         nb: {
           piece,
           content,
@@ -83,7 +83,7 @@ export const filecoinOffer = async ({ capability }, context) => {
  */
 export const filecoinSubmit = async ({ capability }, context) => {
   const { piece, content } = capability.nb
-  const group = context.id.did()
+  const group = context.storefrontSigner.did()
 
   // Queue `piece/offer` invocation
   const res = await context.pieceOfferQueue.add({
@@ -100,9 +100,9 @@ export const filecoinSubmit = async ({ capability }, context) => {
   // Create effect for receipt
   const fx = await AggregatorCaps.pieceOffer
     .invoke({
-      issuer: context.id,
+      issuer: context.storefrontSigner,
       audience: context.aggregatorId,
-      with: context.id.did(),
+      with: context.storefrontSigner.did(),
       nb: {
         piece,
         group,
@@ -132,9 +132,9 @@ export const filecoinAccept = async ({ capability }, context) => {
   const { group } = getPieceRes.ok
   const fx = await AggregatorCaps.pieceOffer
     .invoke({
-      issuer: context.id,
+      issuer: context.storefrontSigner,
       audience: context.aggregatorId,
-      with: context.id.did(),
+      with: context.storefrontSigner.did(),
       nb: {
         piece,
         group,
@@ -267,7 +267,7 @@ export function createService(context) {
  */
 export const createServer = (context) =>
   Server.create({
-    id: context.id,
+    id: context.storefrontSigner,
     codec: context.codec || CAR.inbound,
     service: createService(context),
     catch: (error) => context.errorReporter.catch(error),

--- a/packages/filecoin-api/test/events/storefront.js
+++ b/packages/filecoin-api/test/events/storefront.js
@@ -34,7 +34,7 @@ export const test = {
     const message = {
       piece: cargo.link.link(),
       content: cargo.content.link(),
-      group: context.id.did(),
+      group: context.storefrontSigner.did(),
     }
 
     // Handle message
@@ -60,7 +60,7 @@ export const test = {
     const message = {
       piece: cargo.link.link(),
       content: cargo.content.link(),
-      group: context.id.did(),
+      group: context.storefrontSigner.did(),
     }
     /** @type {PieceRecord} */
     const pieceRecord = {
@@ -95,7 +95,7 @@ export const test = {
         const message = {
           piece: cargo.link.link(),
           content: cargo.content.link(),
-          group: context.id.did(),
+          group: context.storefrontSigner.did(),
         }
 
         // Handle message
@@ -117,7 +117,7 @@ export const test = {
     const message = {
       piece: cargo.link.link(),
       content: cargo.content.link(),
-      group: context.id.did(),
+      group: context.storefrontSigner.did(),
     }
 
     // Handle message
@@ -150,7 +150,7 @@ export const test = {
         const message = {
           piece: cargo.link.link(),
           content: cargo.content.link(),
-          group: context.id.did(),
+          group: context.storefrontSigner.did(),
         }
 
         // Handle message
@@ -185,8 +185,8 @@ export const test = {
           aggregatorService: {
             connection: aggregatorConnection,
             invocationConfig: {
-              issuer: context.id,
-              with: context.id.did(),
+              issuer: context.storefrontSigner,
+              with: context.storefrontSigner.did(),
               audience: aggregatorSigner,
             },
           },
@@ -201,7 +201,7 @@ export const test = {
     const message = {
       piece: cargo.link.link(),
       content: cargo.content.link(),
-      group: context.id.did(),
+      group: context.storefrontSigner.did(),
     }
     /** @type {PieceRecord} */
     const pieceRecord = {
@@ -242,7 +242,7 @@ export const test = {
     const message = {
       piece: cargo.link.link(),
       content: cargo.content.link(),
-      group: context.id.did(),
+      group: context.storefrontSigner.did(),
     }
     /** @type {PieceRecord} */
     const pieceRecord = {
@@ -286,7 +286,7 @@ export const test = {
     const message = {
       piece: cargo.link.link(),
       content: cargo.content.link(),
-      group: context.id.did(),
+      group: context.storefrontSigner.did(),
     }
     /** @type {PieceRecord} */
     const pieceRecord = {
@@ -309,7 +309,7 @@ export const test = {
     context
   ) => {
     const { dealer } = await getServiceContext()
-    const group = context.id.did()
+    const group = context.storefrontSigner.did()
 
     // Create piece and aggregate for test
     const { aggregate, pieces } = await randomAggregate(10, 128)
@@ -323,7 +323,7 @@ export const test = {
         const putRes = await context.pieceStore.put({
           piece: p.link,
           content: p.content,
-          group: context.id.did(),
+          group: context.storefrontSigner.did(),
           status: 'submitted',
           insertedAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
@@ -359,7 +359,7 @@ export const test = {
     // Create invocation and receipts chain until deal
     const { invocations, receipts } =
       await createInvocationsAndReceiptsForDealDataProofChain({
-        storefront: context.id,
+        storefront: context.storefrontSigner,
         aggregator: context.aggregatorId,
         dealer,
         aggregate: aggregate.link,

--- a/packages/filecoin-api/test/services/storefront.js
+++ b/packages/filecoin-api/test/services/storefront.js
@@ -30,7 +30,7 @@ export const test = {
     async (assert, context) => {
       const { agent } = await getServiceContext()
       const connection = connect({
-        id: context.id,
+        id: context.storefrontSigner,
         channel: createServer(context),
       })
 
@@ -58,9 +58,9 @@ export const test = {
       // Validate effects in receipt
       const fxFork = await Filecoin.submit
         .invoke({
-          issuer: context.id,
-          audience: context.id,
-          with: context.id.did(),
+          issuer: context.storefrontSigner,
+          audience: context.storefrontSigner,
+          with: context.storefrontSigner.did(),
           nb: {
             piece: cargo.link.link(),
             content: cargo.content.link(),
@@ -70,9 +70,9 @@ export const test = {
         .delegate()
       const fxJoin = await Filecoin.accept
         .invoke({
-          issuer: context.id,
-          audience: context.id,
-          with: context.id.did(),
+          issuer: context.storefrontSigner,
+          audience: context.storefrontSigner,
+          with: context.storefrontSigner.did(),
           nb: {
             piece: cargo.link.link(),
             content: cargo.content.link(),
@@ -101,7 +101,7 @@ export const test = {
     async (assert, context) => {
       const { agent } = await getServiceContext()
       const connection = connect({
-        id: context.id,
+        id: context.storefrontSigner,
         channel: createServer(context),
       })
 
@@ -112,7 +112,7 @@ export const test = {
       const putRes = await context.pieceStore.put({
         piece: cargo.link.link(),
         content: cargo.content.link(),
-        group: context.id.did(),
+        group: context.storefrontSigner.did(),
         status: 'submitted',
         insertedAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
@@ -140,9 +140,9 @@ export const test = {
       // Validate effects in receipt
       const fxFork = await Filecoin.submit
         .invoke({
-          issuer: context.id,
-          audience: context.id,
-          with: context.id.did(),
+          issuer: context.storefrontSigner,
+          audience: context.storefrontSigner,
+          with: context.storefrontSigner.did(),
           nb: {
             piece: cargo.link.link(),
             content: cargo.content.link(),
@@ -152,9 +152,9 @@ export const test = {
         .delegate()
       const fxJoin = await Filecoin.accept
         .invoke({
-          issuer: context.id,
-          audience: context.id,
-          with: context.id.did(),
+          issuer: context.storefrontSigner,
+          audience: context.storefrontSigner,
+          with: context.storefrontSigner.did(),
           nb: {
             piece: cargo.link.link(),
             content: cargo.content.link(),
@@ -178,7 +178,7 @@ export const test = {
       async (assert, context) => {
         const { agent } = await getServiceContext()
         const connection = connect({
-          id: context.id,
+          id: context.storefrontSigner,
           channel: createServer(context),
         })
 
@@ -210,7 +210,7 @@ export const test = {
       async (assert, context) => {
         const { agent } = await getServiceContext()
         const connection = connect({
-          id: context.id,
+          id: context.storefrontSigner,
           channel: createServer(context),
         })
 
@@ -241,7 +241,7 @@ export const test = {
     async (assert, context) => {
       const { agent } = await getServiceContext()
       const connection = connect({
-        id: context.id,
+        id: context.storefrontSigner,
         channel: createServer(context),
       })
 
@@ -267,12 +267,12 @@ export const test = {
       // Validate effects in receipt
       const fxJoin = await Aggregator.pieceOffer
         .invoke({
-          issuer: context.id,
+          issuer: context.storefrontSigner,
           audience: context.aggregatorId,
-          with: context.id.did(),
+          with: context.storefrontSigner.did(),
           nb: {
             piece: cargo.link.link(),
-            group: context.id.did(),
+            group: context.storefrontSigner.did(),
           },
           expiration: Infinity,
         })
@@ -286,7 +286,7 @@ export const test = {
       async (assert, context) => {
         const { agent } = await getServiceContext()
         const connection = connect({
-          id: context.id,
+          id: context.storefrontSigner,
           channel: createServer(context),
         })
 
@@ -316,9 +316,9 @@ export const test = {
     context
   ) => {
     const { agent, aggregator, dealer } = await getServiceContext()
-    const group = context.id.did()
+    const group = context.storefrontSigner.did()
     const connection = connect({
-      id: context.id,
+      id: context.storefrontSigner,
       channel: createServer({
         ...context,
         aggregatorId: aggregator,
@@ -335,7 +335,7 @@ export const test = {
     const putRes = await context.pieceStore.put({
       piece: piece.link,
       content: piece.content,
-      group: context.id.did(),
+      group: context.storefrontSigner.did(),
       status: 'submitted',
       insertedAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -357,7 +357,7 @@ export const test = {
     }
     const { invocations, receipts } =
       await createInvocationsAndReceiptsForDealDataProofChain({
-        storefront: context.id,
+        storefront: context.storefrontSigner,
         aggregator,
         dealer,
         aggregate: aggregate.link,
@@ -427,7 +427,7 @@ export const test = {
       async (assert, context) => {
         const { agent } = await getServiceContext()
         const connection = connect({
-          id: context.id,
+          id: context.storefrontSigner,
           channel: createServer(context),
         })
 

--- a/packages/filecoin-api/test/storefront.spec.js
+++ b/packages/filecoin-api/test/storefront.spec.js
@@ -38,6 +38,7 @@ describe('storefront', () => {
           },
           {
             id: storefrontSigner,
+            storefrontSigner,
             aggregatorId: aggregatorSigner,
             errorReporter: {
               catch(error) {
@@ -92,6 +93,7 @@ describe('storefront', () => {
           },
           {
             id: storefrontSigner,
+            storefrontSigner,
             aggregatorId: aggregatorSigner,
             pieceStore,
             receiptStore,

--- a/packages/filecoin-api/test/types.ts
+++ b/packages/filecoin-api/test/types.ts
@@ -40,7 +40,7 @@ export interface StorefrontTestEventsContext
     StorefrontInterface.PieceOfferMessageContext,
     StorefrontInterface.StorefrontClientContext,
     StorefrontInterface.CronContext {
-  id: Signer
+  storefrontSigner: Signer
   aggregatorId: Signer
   service: Partial<{
     filecoin: Partial<import('../src/types.js').StorefrontService['filecoin']>

--- a/packages/upload-api/src/lib.js
+++ b/packages/upload-api/src/lib.js
@@ -31,7 +31,6 @@ export const createServer = ({ id, codec = Legacy.inbound, ...context }) =>
     codec,
     service: createService({
       ...context,
-      id
     }),
     catch: (error) => context.errorReporter.catch(error),
   })

--- a/packages/upload-api/test/helpers/context.js
+++ b/packages/upload-api/test/helpers/context.js
@@ -44,6 +44,7 @@ export const createContext = async (options = {}) => {
   /** @type { import('../../src/types.js').UcantoServerContext } */
   const serviceContext = {
     id,
+    storefrontSigner: id,
     aggregatorId: aggregatorSigner,
     signer: id,
     email: Email.debug(),


### PR DESCRIPTION
Per https://github.com/web3-storage/w3filecoin-infra/issues/52 make storefront now same signer as aggregator to enable receipt chain