### PR TITLE
feat: optionally require plans for provisioning

### DIFF
--- a/packages/upload-api/src/provider-add.js
+++ b/packages/upload-api/src/provider-add.js
@@ -17,7 +17,7 @@ export const provide = (ctx) =>
  */
 export const add = async (
   { capability, invocation },
-  { provisionsStorage: provisions, rateLimitsStorage: rateLimits }
+  { provisionsStorage: provisions, rateLimitsStorage: rateLimits, plansStorage, planRequiredForProvisioning }
 ) => {
   const {
     nb: { consumer, provider },
@@ -40,15 +40,27 @@ export const add = async (
     [mailtoDidToDomain(accountMailtoDID), mailtoDidToEmail(accountMailtoDID)],
     0
   )
-
   if (rateLimitResult.error) {
     return {
       error: {
         name: 'AccountBlocked',
-        message: `Account identified by ${accountDID} is blocked`,
+        message: `Account identified by ${accountMailtoDID} is blocked`,
       },
     }
   }
+
+  if (planRequiredForProvisioning) {
+    const planGetResult = await plansStorage.get(accountMailtoDID)
+    if (!planGetResult.ok?.product) {
+      return {
+        error: {
+          name: 'AccountPlanMissing',
+          message: `Account identified by ${accountMailtoDID} has not selected a payment plan`,
+        },
+      }
+    }
+  }
+
   if (!provisions.services.includes(provider)) {
     return {
       error: {

--- a/packages/upload-api/src/provider-add.js
+++ b/packages/upload-api/src/provider-add.js
@@ -17,7 +17,7 @@ export const provide = (ctx) =>
  */
 export const add = async (
   { capability, invocation },
-  { provisionsStorage: provisions, rateLimitsStorage: rateLimits, plansStorage, planRequiredForProvisioning }
+  { provisionsStorage: provisions, rateLimitsStorage: rateLimits, plansStorage, requirePaymentPlan }
 ) => {
   const {
     nb: { consumer, provider },
@@ -49,7 +49,7 @@ export const add = async (
     }
   }
 
-  if (planRequiredForProvisioning) {
+  if (requirePaymentPlan) {
     const planGetResult = await plansStorage.get(accountMailtoDID)
     if (!planGetResult.ok?.product) {
       return {

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -313,7 +313,7 @@ export interface ProviderServiceContext {
   provisionsStorage: Provisions
   rateLimitsStorage: RateLimits
   plansStorage: PlansStorage
-  planRequiredForProvisioning?: boolean
+  requirePaymentPlan?: boolean
 }
 
 export interface SubscriptionServiceContext {

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -312,6 +312,8 @@ export interface SpaceServiceContext {
 export interface ProviderServiceContext {
   provisionsStorage: Provisions
   rateLimitsStorage: RateLimits
+  plansStorage: PlansStorage
+  planRequiredForProvisioning?: boolean
 }
 
 export interface SubscriptionServiceContext {

--- a/packages/upload-api/test/handlers/provider-add.spec.js
+++ b/packages/upload-api/test/handlers/provider-add.spec.js
@@ -260,7 +260,7 @@ describe(`provider/add`, () => {
 
   it('provider/add fails if plans are required and a plan has not been configured', async () => {
     const { space, agent, account, ...context } = await setup({
-      planRequiredForProvisioning: true
+      requirePaymentPlan: true
     })
     const { service } = context
 

--- a/packages/upload-api/test/handlers/provider-add.spec.js
+++ b/packages/upload-api/test/handlers/provider-add.spec.js
@@ -257,6 +257,35 @@ describe(`provider/add`, () => {
       cleanupContext(context)
     }
   })
+
+  it('provider/add fails if plans are required and a plan has not been configured', async () => {
+    const { space, agent, account, ...context } = await setup({
+      planRequiredForProvisioning: true
+    })
+    const { service } = context
+
+    try {
+      const proofs = await createAuthorization({ agent, service, account })
+
+      const addResult = await Provider.add
+        .invoke({
+          issuer: agent,
+          audience: service,
+          with: account.did(),
+          nb: {
+            provider: 'did:web:web3.storage',
+            consumer: space.did(),
+          },
+          proofs,
+        })
+        .execute(context.connection)
+
+      assert.ok(addResult.out.error, 'Expected error provisioning without adding a plan')
+      assert.equal(addResult.out.error.message, `Account identified by ${account.did()} has not selected a payment plan`)
+    } finally {
+      cleanupContext(context)
+    }
+  })
 })
 
 /**

--- a/packages/upload-api/test/helpers/context.js
+++ b/packages/upload-api/test/helpers/context.js
@@ -23,11 +23,13 @@ import { UsageStorage } from '../storage/usage-storage.js'
 /**
  * @param {object} options
  * @param {string[]} [options.providers]
+ * @param {boolean} [options.planRequiredForProvisioning]
  * @param {import('http')} [options.http]
  * @param {{fail(error:unknown): unknown}} [options.assert]
  * @returns {Promise<Types.UcantoServerTestContext>}
  */
-export const createContext = async (options = {}) => {
+export const createContext = async (options = { planRequiredForProvisioning: false }) => {
+  const planRequiredForProvisioning = options.planRequiredForProvisioning
   const storeTable = new StoreTable()
   const uploadTable = new UploadTable()
   const carStoreBucket = await CarStoreBucket.activate(options)
@@ -81,6 +83,7 @@ export const createContext = async (options = {}) => {
     pieceStore,
     receiptStore,
     taskStore,
+    planRequiredForProvisioning,
     ...createRevocationChecker({ revocationsStorage }),
   }
 

--- a/packages/upload-api/test/helpers/context.js
+++ b/packages/upload-api/test/helpers/context.js
@@ -23,13 +23,13 @@ import { UsageStorage } from '../storage/usage-storage.js'
 /**
  * @param {object} options
  * @param {string[]} [options.providers]
- * @param {boolean} [options.planRequiredForProvisioning]
+ * @param {boolean} [options.requirePaymentPlan]
  * @param {import('http')} [options.http]
  * @param {{fail(error:unknown): unknown}} [options.assert]
  * @returns {Promise<Types.UcantoServerTestContext>}
  */
-export const createContext = async (options = { planRequiredForProvisioning: false }) => {
-  const planRequiredForProvisioning = options.planRequiredForProvisioning
+export const createContext = async (options = { requirePaymentPlan: false }) => {
+  const requirePaymentPlan = options.requirePaymentPlan
   const storeTable = new StoreTable()
   const uploadTable = new UploadTable()
   const carStoreBucket = await CarStoreBucket.activate(options)
@@ -83,7 +83,7 @@ export const createContext = async (options = { planRequiredForProvisioning: fal
     pieceStore,
     receiptStore,
     taskStore,
-    planRequiredForProvisioning,
+    requirePaymentPlan,
     ...createRevocationChecker({ revocationsStorage }),
   }
 


### PR DESCRIPTION
We need this to ship billing, to stop users without a payment provider plan from provisioning new spaces.

I've added a flag to the `ProviderServiceContext` that lets us disable this requirement - this is extremely useful in testing and will be helpful as we roll this feature out - ie, w3infra can disable this requirement until we are ready to launch.