### PR TITLE
feat: add `subscription/list` capability

### DIFF
--- a/packages/access-client/src/access.js
+++ b/packages/access-client/src/access.js
@@ -334,6 +334,7 @@ export const spaceAccess = {
   'upload/*': {},
   'access/*': {},
   'filecoin/*': {},
+  'usage/*': {},
 }
 
 /**

--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -183,6 +183,7 @@ export async function authorizeAndWait(access, email, opts = {}) {
       { can: 'space/*' },
       { can: 'store/*' },
       { can: 'provider/add' },
+      { can: 'subscription/list' },
       { can: 'upload/*' },
       { can: 'ucan/*' },
       { can: 'plan/*' },

--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -52,6 +52,9 @@ import type {
   PlanGet,
   PlanGetSuccess,
   PlanGetFailure,
+  SubscriptionList,
+  SubscriptionListSuccess,
+  SubscriptionListFailure,
 } from '@web3-storage/capabilities/types'
 import type { SetRequired } from 'type-fest'
 import { Driver } from './drivers/types.js'
@@ -115,6 +118,13 @@ export interface Service {
   }
   space: {
     info: ServiceMethod<SpaceInfo, SpaceInfoResult, Failure | SpaceUnknown>
+  }
+  subscription: {
+    list: ServiceMethod<
+      SubscriptionList,
+      SubscriptionListSuccess,
+      SubscriptionListFailure
+    >
   }
   ucan: {
     revoke: ServiceMethod<UCANRevoke, UCANRevokeSuccess, UCANRevokeFailure>

--- a/packages/capabilities/src/customer.js
+++ b/packages/capabilities/src/customer.js
@@ -1,10 +1,8 @@
 import { capability, DID, struct, ok } from '@ucanto/validator'
-import { equalWith, and, equal } from './utils.js'
+import { AccountDID, equalWith, and, equal } from './utils.js'
 
 // e.g. did:web:web3.storage or did:web:staging.web3.storage
 export const ProviderDID = DID.match({ method: 'web' })
-
-export const AccountDID = DID.match({ method: 'mailto' })
 
 /**
  * Capability can be invoked by a provider to get information about the

--- a/packages/capabilities/src/index.js
+++ b/packages/capabilities/src/index.js
@@ -67,6 +67,7 @@ export const abilitiesAsStrings = [
   Consumer.has.can,
   Consumer.get.can,
   Subscription.get.can,
+  Subscription.list.can,
   RateLimit.add.can,
   RateLimit.remove.can,
   RateLimit.list.can,

--- a/packages/capabilities/src/plan.js
+++ b/packages/capabilities/src/plan.js
@@ -1,7 +1,5 @@
-import { capability, DID, ok } from '@ucanto/validator'
-import { equalWith, and } from './utils.js'
-
-export const AccountDID = DID.match({ method: 'mailto' })
+import { capability, ok } from '@ucanto/validator'
+import { AccountDID, equalWith, and } from './utils.js'
 
 /**
  * Capability can be invoked by an account to get information about

--- a/packages/capabilities/src/provider.js
+++ b/packages/capabilities/src/provider.js
@@ -9,12 +9,12 @@
  * @module
  */
 import { capability, DID, struct, ok } from '@ucanto/validator'
-import { equalWith, and, equal, SpaceDID } from './utils.js'
+import { AccountDID, equalWith, and, equal, SpaceDID } from './utils.js'
 
 // e.g. did:web:web3.storage or did:web:staging.web3.storage
 export const Provider = DID.match({ method: 'web' })
 
-export const AccountDID = DID.match({ method: 'mailto' })
+export { AccountDID }
 
 /**
  * Capability can be invoked by an agent to add a provider to a space.

--- a/packages/capabilities/src/subscription.js
+++ b/packages/capabilities/src/subscription.js
@@ -1,5 +1,5 @@
 import { capability, DID, struct, ok, Schema } from '@ucanto/validator'
-import { equalWith, and, equal } from './utils.js'
+import { AccountDID, equalWith, and, equal } from './utils.js'
 
 // e.g. did:web:web3.storage or did:web:staging.web3.storage
 export const ProviderDID = DID.match({ method: 'web' })
@@ -20,4 +20,14 @@ export const get = capability({
       ok({})
     )
   },
+})
+
+/**
+ * Capability can be invoked to retrieve the list of subscriptions for an
+ * account.
+ */
+export const list = capability({
+  can: 'subscription/list',
+  with: AccountDID,
+  derives: equalWith,
 })

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -196,6 +196,19 @@ export type SubscriptionGetFailure =
   | UnknownProvider
   | Ucanto.Failure
 
+export type SubscriptionList = InferInvokedCapability<
+  typeof SubscriptionCaps.list
+>
+export interface SubscriptionListSuccess {
+  results: Array<SubscriptionListItem>
+}
+export interface SubscriptionListItem {
+  subscription: string
+  provider: ProviderDID
+  consumers: SpaceDID[]
+}
+export type SubscriptionListFailure = Ucanto.Failure
+
 // Rate Limit
 export type RateLimitAdd = InferInvokedCapability<typeof RateLimitCaps.add>
 export interface RateLimitAddSuccess {
@@ -622,6 +635,7 @@ export type AbilitiesArray = [
   ConsumerHas['can'],
   ConsumerGet['can'],
   SubscriptionGet['can'],
+  SubscriptionList['can'],
   RateLimitAdd['can'],
   RateLimitRemove['can'],
   RateLimitList['can'],

--- a/packages/capabilities/src/utils.js
+++ b/packages/capabilities/src/utils.js
@@ -7,6 +7,8 @@ export const ProviderDID = DID.match({ method: 'web' })
 
 export const SpaceDID = DID.match({ method: 'key' })
 
+export const AccountDID = DID.match({ method: 'mailto' })
+
 /**
  * Check URI can be delegated
  *

--- a/packages/upload-api/src/subscription.js
+++ b/packages/upload-api/src/subscription.js
@@ -1,9 +1,11 @@
 import * as Types from './types.js'
 import * as Get from './subscription/get.js'
+import * as List from './subscription/list.js'
 
 /**
  * @param {Types.SubscriptionServiceContext} context
  */
 export const createService = (context) => ({
   get: Get.provide(context),
+  list: List.provide(context),
 })

--- a/packages/upload-api/src/subscription/list.js
+++ b/packages/upload-api/src/subscription/list.js
@@ -1,0 +1,17 @@
+import * as API from '../types.js'
+import * as Server from '@ucanto/server'
+import { Subscription } from '@web3-storage/capabilities'
+
+/**
+ * @param {API.SubscriptionServiceContext} context
+ */
+export const provide = (context) =>
+  Server.provide(Subscription.list, (input) => list(input, context))
+
+/**
+ * @param {API.Input<Subscription.list>} input
+ * @param {API.SubscriptionServiceContext} context
+ * @returns {Promise<API.Result<API.SubscriptionListSuccess, API.SubscriptionListFailure>>}
+ */
+const list = async ({ capability }, context) =>
+  context.subscriptionsStorage.list(capability.with)

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -95,6 +95,9 @@ import {
   SubscriptionGet,
   SubscriptionGetSuccess,
   SubscriptionGetFailure,
+  SubscriptionList,
+  SubscriptionListSuccess,
+  SubscriptionListFailure,
   RateLimitAdd,
   RateLimitAddSuccess,
   RateLimitAddFailure,
@@ -152,6 +155,8 @@ export type {
 export type { RateLimitsStorage, RateLimit } from './types/rate-limits.js'
 import { PlansStorage } from './types/plans.js'
 export type { PlansStorage } from './types/plans.js'
+import { SubscriptionsStorage } from './types/subscriptions.js'
+export type { SubscriptionsStorage } from './types/subscriptions.js'
 
 export interface Service extends StorefrontService {
   store: {
@@ -208,6 +213,11 @@ export interface Service extends StorefrontService {
       SubscriptionGet,
       SubscriptionGetSuccess,
       SubscriptionGetFailure
+    >
+    list: ServiceMethod<
+      SubscriptionList,
+      SubscriptionListSuccess,
+      SubscriptionListFailure
     >
   }
   'rate-limit': {
@@ -319,6 +329,7 @@ export interface ProviderServiceContext {
 export interface SubscriptionServiceContext {
   signer: EdSigner.Signer
   provisionsStorage: Provisions
+  subscriptionsStorage: SubscriptionsStorage
 }
 
 export interface RateLimitServiceContext {

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -156,7 +156,7 @@ export type { RateLimitsStorage, RateLimit } from './types/rate-limits.js'
 import { PlansStorage } from './types/plans.js'
 export type { PlansStorage } from './types/plans.js'
 import { SubscriptionsStorage } from './types/subscriptions.js'
-export type { SubscriptionsStorage } from './types/subscriptions.js'
+export type { SubscriptionsStorage }
 
 export interface Service extends StorefrontService {
   store: {

--- a/packages/upload-api/src/types/subscriptions.ts
+++ b/packages/upload-api/src/types/subscriptions.ts
@@ -7,6 +7,6 @@ import {
 
 export interface SubscriptionsStorage {
   list: (
-    account: AccountDID
+    customer: AccountDID
   ) => Promise<Result<SubscriptionListSuccess, SubscriptionListFailure>>
 }

--- a/packages/upload-api/src/types/subscriptions.ts
+++ b/packages/upload-api/src/types/subscriptions.ts
@@ -1,0 +1,12 @@
+import { Result } from '@ucanto/interface'
+import {
+  AccountDID,
+  SubscriptionListSuccess,
+  SubscriptionListFailure
+} from '@web3-storage/capabilities/types'
+
+export interface SubscriptionsStorage {
+  list: (
+    account: AccountDID
+  ) => Promise<Result<SubscriptionListSuccess, SubscriptionListFailure>>
+}

--- a/packages/upload-api/src/types/subscriptions.ts
+++ b/packages/upload-api/src/types/subscriptions.ts
@@ -2,7 +2,7 @@ import { Result } from '@ucanto/interface'
 import {
   AccountDID,
   SubscriptionListSuccess,
-  SubscriptionListFailure
+  SubscriptionListFailure,
 } from '@web3-storage/capabilities/types'
 
 export interface SubscriptionsStorage {

--- a/packages/upload-api/test/handlers/subscription.js
+++ b/packages/upload-api/test/handlers/subscription.js
@@ -1,0 +1,43 @@
+import { Subscription } from '@web3-storage/capabilities'
+import * as API from '../../src/types.js'
+import { createServer, connect } from '../../src/lib.js'
+import { alice, registerSpace } from '../util.js'
+import { createAuthorization } from '../helpers/utils.js'
+
+/** @type {API.Tests} */
+export const test = {
+  'subscription/list retrieves subscriptions for account': async (assert, context) => {
+    const spaces = await Promise.all([
+      registerSpace(alice, context, 'alic_e'),
+      registerSpace(alice, context, 'alic_e')
+    ])
+    const connection = connect({
+      id: context.id,
+      channel: createServer(context),
+    })
+
+    const subListRes = await Subscription.list
+      .invoke({
+        issuer: alice,
+        audience: context.id,
+        with: spaces[0].account.did(),
+        nb: {},
+        proofs: await createAuthorization({
+          agent: alice,
+          account: spaces[0].account,
+          service: context.service,
+        }),
+      })
+      .execute(connection)
+
+    assert.ok(subListRes.out.ok)
+
+    const results = subListRes.out.ok?.results
+    const totalConsumers = results?.reduce((total, s) => total + s.consumers.length, 0)
+    assert.equal(totalConsumers, spaces.length)
+
+    for (const space of spaces) {
+      assert.ok(results?.some(s => s.consumers[0] === space.spaceDid))
+    }
+  },
+}

--- a/packages/upload-api/test/handlers/subscription.js
+++ b/packages/upload-api/test/handlers/subscription.js
@@ -6,10 +6,13 @@ import { createAuthorization } from '../helpers/utils.js'
 
 /** @type {API.Tests} */
 export const test = {
-  'subscription/list retrieves subscriptions for account': async (assert, context) => {
+  'subscription/list retrieves subscriptions for account': async (
+    assert,
+    context
+  ) => {
     const spaces = await Promise.all([
       registerSpace(alice, context, 'alic_e'),
-      registerSpace(alice, context, 'alic_e')
+      registerSpace(alice, context, 'alic_e'),
     ])
     const connection = connect({
       id: context.id,
@@ -33,11 +36,14 @@ export const test = {
     assert.ok(subListRes.out.ok)
 
     const results = subListRes.out.ok?.results
-    const totalConsumers = results?.reduce((total, s) => total + s.consumers.length, 0)
+    const totalConsumers = results?.reduce(
+      (total, s) => total + s.consumers.length,
+      0
+    )
     assert.equal(totalConsumers, spaces.length)
 
     for (const space of spaces) {
-      assert.ok(results?.some(s => s.consumers[0] === space.spaceDid))
+      assert.ok(results?.some((s) => s.consumers[0] === space.spaceDid))
     }
   },
 }

--- a/packages/upload-api/test/handlers/subscription.spec.js
+++ b/packages/upload-api/test/handlers/subscription.spec.js
@@ -1,0 +1,3 @@
+import * as Subscription from './subscription.js'
+import { test } from '../test.js'
+test({ 'subscription/*': Subscription.test })

--- a/packages/upload-api/test/handlers/usage.js
+++ b/packages/upload-api/test/handlers/usage.js
@@ -43,7 +43,6 @@ export const test = {
       /** @type {import('../types.js').ProviderDID} */
       (context.id.did())
     const report = usageReportRes.out.ok?.[provider]
-    console.log(report)
     assert.equal(report?.space, spaceDid)
     assert.equal(report?.size.initial, 0)
     assert.equal(report?.size.final, size)

--- a/packages/upload-api/test/helpers/context.js
+++ b/packages/upload-api/test/helpers/context.js
@@ -21,6 +21,7 @@ import * as TestTypes from '../types.js'
 import { confirmConfirmationUrl } from './utils.js'
 import { PlansStorage } from '../storage/plans-storage.js'
 import { UsageStorage } from '../storage/usage-storage.js'
+import { SubscriptionsStorage } from '../storage/subscriptions-storage.js'
 
 /**
  * @param {object} options
@@ -41,6 +42,8 @@ export const createContext = async (
   const revocationsStorage = new RevocationsStorage()
   const plansStorage = new PlansStorage()
   const usageStorage = new UsageStorage(storeTable)
+  const provisionsStorage = new ProvisionsStorage(options.providers)
+  const subscriptionsStorage = new SubscriptionsStorage(provisionsStorage)
   const signer = await Signer.generate()
   const aggregatorSigner = await Signer.generate()
   const dealTrackerSigner = await Signer.generate()
@@ -69,7 +72,8 @@ export const createContext = async (
     signer: id,
     email,
     url: new URL('http://localhost:8787'),
-    provisionsStorage: new ProvisionsStorage(options.providers),
+    provisionsStorage,
+    subscriptionsStorage,
     delegationsStorage: new DelegationsStorage(),
     rateLimitsStorage: new RateLimitsStorage(),
     plansStorage,

--- a/packages/upload-api/test/lib.js
+++ b/packages/upload-api/test/lib.js
@@ -7,6 +7,7 @@ import * as RateLimitAdd from './handlers/rate-limit/add.js'
 import * as RateLimitList from './handlers/rate-limit/list.js'
 import * as RateLimitRemove from './handlers/rate-limit/remove.js'
 import * as Store from './handlers/store.js'
+import * as Subscription from './handlers/subscription.js'
 import * as Upload from './handlers/upload.js'
 import * as Plan from './handlers/plan.js'
 import * as Usage from './handlers/usage.js'
@@ -43,6 +44,7 @@ export const handlerTests = {
   ...RateLimitList,
   ...RateLimitRemove,
   ...Store.test,
+  ...Subscription.test,
   ...Upload.test,
   ...Plan.test,
   ...Usage.test,

--- a/packages/upload-api/test/storage/subscriptions-storage.js
+++ b/packages/upload-api/test/storage/subscriptions-storage.js
@@ -7,7 +7,7 @@
  */
 export class SubscriptionsStorage {
   /** @param {import('./provisions-storage.js').ProvisionsStorage} provisions */
-  constructor (provisions) {
+  constructor(provisions) {
     this.provisionsStore = provisions
   }
 
@@ -21,7 +21,7 @@ export class SubscriptionsStorage {
       results.push({
         subscription,
         provider: provision.provider,
-        consumers: [provision.consumer]
+        consumers: [provision.consumer],
       })
     }
     return { ok: { results } }

--- a/packages/upload-api/test/storage/subscriptions-storage.js
+++ b/packages/upload-api/test/storage/subscriptions-storage.js
@@ -11,17 +11,17 @@ export class SubscriptionsStorage {
     this.provisionsStore = provisions
   }
 
-  /** @param {import('../types.js').AccountDID} account */
-  async list(account) {
+  /** @param {import('../types.js').AccountDID} customer */
+  async list(customer) {
     /** @type {import('../types.js').SubscriptionListItem[]} */
     const results = []
     const entries = Object.entries(this.provisionsStore.provisions)
-    for (const [subscription, { customer, provider, consumer }] of entries) {
-      if (customer !== account) continue
+    for (const [subscription, provision] of entries) {
+      if (provision.customer !== customer) continue
       results.push({
         subscription,
-        provider,
-        consumers: [consumer]
+        provider: provision.provider,
+        consumers: [provision.consumer]
       })
     }
     return { ok: { results } }

--- a/packages/upload-api/test/storage/subscriptions-storage.js
+++ b/packages/upload-api/test/storage/subscriptions-storage.js
@@ -1,0 +1,29 @@
+/**
+ * @typedef {import('../../src/types/subscriptions.js').SubscriptionsStorage} SubscriptionsStore
+ */
+
+/**
+ * @implements {SubscriptionsStore}
+ */
+export class SubscriptionsStorage {
+  /** @param {import('./provisions-storage.js').ProvisionsStorage} provisions */
+  constructor (provisions) {
+    this.provisionsStore = provisions
+  }
+
+  /** @param {import('../types.js').AccountDID} account */
+  async list(account) {
+    /** @type {import('../types.js').SubscriptionListItem[]} */
+    const results = []
+    const entries = Object.entries(this.provisionsStore.provisions)
+    for (const [subscription, { customer, provider, consumer }] of entries) {
+      if (customer !== account) continue
+      results.push({
+        subscription,
+        provider,
+        consumers: [consumer]
+      })
+    }
+    return { ok: { results } }
+  }
+}

--- a/packages/upload-api/test/util.js
+++ b/packages/upload-api/test/util.js
@@ -50,9 +50,9 @@ export async function createSpace(audience) {
 }
 
 /**
- *
  * @param {API.Principal & API.Signer} audience
  * @param {import('./types.js').UcantoServerTestContext} context
+ * @param {string} [username]
  */
 export const registerSpace = async (audience, context, username = 'alice') => {
   const { proof, space, spaceDid } = await createSpace(audience)
@@ -77,7 +77,7 @@ export const registerSpace = async (audience, context, username = 'alice') => {
     })
   }
 
-  return { proof, space, spaceDid }
+  return { proof, space, spaceDid, account }
 }
 
 /** @param {number} size */

--- a/packages/w3up-client/package.json
+++ b/packages/w3up-client/package.json
@@ -44,9 +44,17 @@
       "types": "./dist/src/capability/store.d.ts",
       "import": "./src/capability/store.js"
     },
+    "./capability/subscription": {
+      "types": "./dist/src/capability/subscription.d.ts",
+      "import": "./src/capability/subscription.js"
+    },
     "./capability/upload": {
       "types": "./dist/src/capability/upload.d.ts",
       "import": "./src/capability/upload.js"
+    },
+    "./capability/usage": {
+      "types": "./dist/src/capability/usage.d.ts",
+      "import": "./src/capability/usage.js"
     },
     "./types": "./src/types.js"
   },

--- a/packages/w3up-client/src/capability/subscription.js
+++ b/packages/w3up-client/src/capability/subscription.js
@@ -7,7 +7,7 @@ import { Base } from '../base.js'
 export class SubscriptionClient extends Base {
   /**
    * List subscriptions for the passed account.
-   * 
+   *
    * @param {import('@web3-storage/access').AccountDID} account
    */
   async list(account) {
@@ -16,18 +16,23 @@ export class SubscriptionClient extends Base {
         issuer: this._agent.issuer,
         audience: this._serviceConf.access.id,
         with: account,
-        proofs: this._agent.proofs([{
-          can: SubscriptionCapabilities.list.can,
-          with: account
-        }]),
+        proofs: this._agent.proofs([
+          {
+            can: SubscriptionCapabilities.list.can,
+            with: account,
+          },
+        ]),
         nb: {},
       })
       .execute(this._serviceConf.access)
 
     if (!result.out.ok) {
-      throw new Error(`failed ${SubscriptionCapabilities.list.can} invocation`, {
-        cause: result.out.error,
-      })
+      throw new Error(
+        `failed ${SubscriptionCapabilities.list.can} invocation`,
+        {
+          cause: result.out.error,
+        }
+      )
     }
 
     return result.out.ok

--- a/packages/w3up-client/src/capability/subscription.js
+++ b/packages/w3up-client/src/capability/subscription.js
@@ -1,0 +1,34 @@
+import { Subscription as SubscriptionCapabilities } from '@web3-storage/capabilities'
+import { Base } from '../base.js'
+
+/**
+ * Client for interacting with the `subscription/*` capabilities.
+ */
+export class SubscriptionClient extends Base {
+  /**
+   * List subscriptions for the passed account.
+   * 
+   * @param {import('@web3-storage/access').AccountDID} account
+   */
+  async list(account) {
+    const conf = await this._invocationConfig([SubscriptionCapabilities.list.can])
+
+    const result = await SubscriptionCapabilities.list
+      .invoke({
+        issuer: conf.issuer,
+        audience: conf.audience,
+        with: account,
+        proofs: conf.proofs,
+        nb: {},
+      })
+      .execute(this._serviceConf.access)
+
+    if (!result.out.ok) {
+      throw new Error(`failed ${SubscriptionCapabilities.list.can} invocation`, {
+        cause: result.out.error,
+      })
+    }
+
+    return result.out.ok
+  }
+}

--- a/packages/w3up-client/src/capability/subscription.js
+++ b/packages/w3up-client/src/capability/subscription.js
@@ -11,14 +11,15 @@ export class SubscriptionClient extends Base {
    * @param {import('@web3-storage/access').AccountDID} account
    */
   async list(account) {
-    const conf = await this._invocationConfig([SubscriptionCapabilities.list.can])
-
     const result = await SubscriptionCapabilities.list
       .invoke({
-        issuer: conf.issuer,
-        audience: conf.audience,
+        issuer: this._agent.issuer,
+        audience: this._serviceConf.access.id,
         with: account,
-        proofs: conf.proofs,
+        proofs: this._agent.proofs([{
+          can: SubscriptionCapabilities.list.can,
+          with: account
+        }]),
         nb: {},
       })
       .execute(this._serviceConf.access)

--- a/packages/w3up-client/src/capability/usage.js
+++ b/packages/w3up-client/src/capability/usage.js
@@ -6,22 +6,21 @@ import { Base } from '../base.js'
  */
 export class UsageClient extends Base {
   /**
-   * Get a usage report for the given time period.
+   * Get a usage report for thepassed space in the given time period.
    *
+   * @param {import('../types.js').SpaceDID} space
    * @param {{ from: Date, to: Date }} period
-   * @param {object} [options]
-   * @param {import('../types.js').SpaceDID} [options.space] Obtain usage for a different space.
    */
-  async report(period, options) {
-    const conf = await this._invocationConfig([UsageCapabilities.report.can])
-
+  async report(space, period) {
     const result = await UsageCapabilities.report
       .invoke({
-        issuer: conf.issuer,
-        /* c8 ignore next */
-        audience: conf.audience,
-        with: options?.space ?? conf.with,
-        proofs: conf.proofs,
+        issuer: this._agent.issuer,
+        audience: this._serviceConf.upload.id,
+        with: space,
+        proofs: this._agent.proofs([{
+          can: UsageCapabilities.report.can,
+          with: space
+        }]),
         nb: {
           period: {
             from: Math.floor(period.from.getTime() / 1000),

--- a/packages/w3up-client/src/capability/usage.js
+++ b/packages/w3up-client/src/capability/usage.js
@@ -17,10 +17,12 @@ export class UsageClient extends Base {
         issuer: this._agent.issuer,
         audience: this._serviceConf.upload.id,
         with: space,
-        proofs: this._agent.proofs([{
-          can: UsageCapabilities.report.can,
-          with: space
-        }]),
+        proofs: this._agent.proofs([
+          {
+            can: UsageCapabilities.report.can,
+            with: space,
+          },
+        ]),
         nb: {
           period: {
             from: Math.floor(period.from.getTime() / 1000),

--- a/packages/w3up-client/src/capability/usage.js
+++ b/packages/w3up-client/src/capability/usage.js
@@ -6,7 +6,7 @@ import { Base } from '../base.js'
  */
 export class UsageClient extends Base {
   /**
-   * Get a usage report for thepassed space in the given time period.
+   * Get a usage report for the passed space in the given time period.
    *
    * @param {import('../types.js').SpaceDID} space
    * @param {{ from: Date, to: Date }} period

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -13,6 +13,8 @@ import { Delegation as AgentDelegation } from './delegation.js'
 import { StoreClient } from './capability/store.js'
 import { UploadClient } from './capability/upload.js'
 import { SpaceClient } from './capability/space.js'
+import { SubscriptionClient } from './capability/subscription.js'
+import { UsageClient } from './capability/usage.js'
 import { AccessClient } from './capability/access.js'
 import { FilecoinClient } from './capability/filecoin.js'
 export * as Access from './capability/access.js'
@@ -29,10 +31,12 @@ export class Client extends Base {
     super(agentData, options)
     this.capability = {
       access: new AccessClient(agentData, options),
-      store: new StoreClient(agentData, options),
-      upload: new UploadClient(agentData, options),
-      space: new SpaceClient(agentData, options),
       filecoin: new FilecoinClient(agentData, options),
+      space: new SpaceClient(agentData, options),
+      store: new StoreClient(agentData, options),
+      subscription: new SubscriptionClient(agentData, options),
+      upload: new UploadClient(agentData, options),
+      usage: new UsageClient(agentData, options),
     }
   }
 

--- a/packages/w3up-client/test/capability/subscription.test.js
+++ b/packages/w3up-client/test/capability/subscription.test.js
@@ -17,7 +17,7 @@ describe('SubscriptionClient', () => {
       const subscription = {
         provider: 'did:web:web3.storage',
         subscription: 'test',
-        consumers: [space.did()]
+        consumers: [space.did()],
       }
       const account = Absentee.from({ id: 'did:mailto:example.com:alice' })
       const service = mockService({
@@ -49,7 +49,7 @@ describe('SubscriptionClient', () => {
       const auths = await createAuthorization({
         account,
         service: serviceSigner,
-        agent: alice.agent.issuer
+        agent: alice.agent.issuer,
       })
       await alice.agent.addProofs(auths)
 
@@ -87,14 +87,13 @@ describe('SubscriptionClient', () => {
       const auths = await createAuthorization({
         account,
         service: serviceSigner,
-        agent: alice.agent.issuer
+        agent: alice.agent.issuer,
       })
       await alice.agent.addProofs(auths)
 
-      await assert.rejects(
-        alice.capability.subscription.list(account.did()),
-        { message: 'failed subscription/list invocation' }
-      )
+      await assert.rejects(alice.capability.subscription.list(account.did()), {
+        message: 'failed subscription/list invocation',
+      })
 
       assert(service.subscription.list.called)
       assert.equal(service.subscription.list.callCount, 1)

--- a/packages/w3up-client/test/capability/subscription.test.js
+++ b/packages/w3up-client/test/capability/subscription.test.js
@@ -1,0 +1,103 @@
+import assert from 'assert'
+import { create as createServer, provide } from '@ucanto/server'
+import * as CAR from '@ucanto/transport/car'
+import * as Signer from '@ucanto/principal/ed25519'
+import { Absentee } from '@ucanto/principal'
+import * as SubscriptionCapabilities from '@web3-storage/capabilities/subscription'
+import { AgentData } from '@web3-storage/access/agent'
+import { mockService, mockServiceConf } from '../helpers/mocks.js'
+import { Client } from '../../src/client.js'
+import { createAuthorization, validateAuthorization } from '../helpers/utils.js'
+
+describe('SubscriptionClient', () => {
+  describe('list', () => {
+    it('should list subscriptions', async () => {
+      const space = await Signer.generate()
+      /** @type {import('@web3-storage/capabilities/types').SubscriptionListItem} */
+      const subscription = {
+        provider: 'did:web:web3.storage',
+        subscription: 'test',
+        consumers: [space.did()]
+      }
+      const account = Absentee.from({ id: 'did:mailto:example.com:alice' })
+      const service = mockService({
+        subscription: {
+          list: provide(SubscriptionCapabilities.list, ({ capability }) => {
+            assert.equal(capability.with, account.did())
+            return {
+              ok: {
+                results: [subscription],
+              },
+            }
+          }),
+        },
+      })
+
+      const serviceSigner = await Signer.generate()
+      const server = createServer({
+        id: serviceSigner,
+        service,
+        codec: CAR.inbound,
+        validateAuthorization,
+      })
+
+      const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
+        serviceConf: await mockServiceConf(server),
+      })
+
+      const auths = await createAuthorization({
+        account,
+        service: serviceSigner,
+        agent: alice.agent.issuer
+      })
+      await alice.agent.addProofs(auths)
+
+      const subs = await alice.capability.subscription.list(account.did())
+
+      assert(service.subscription.list.called)
+      assert.equal(service.subscription.list.callCount, 1)
+      assert.deepEqual(subs, { results: [subscription] })
+    })
+
+    it('should throw on service failure', async () => {
+      const account = Absentee.from({ id: 'did:mailto:example.com:alice' })
+      const service = mockService({
+        subscription: {
+          list: provide(SubscriptionCapabilities.list, ({ capability }) => {
+            assert.equal(capability.with, account.did())
+            return { error: new Error('boom') }
+          }),
+        },
+      })
+
+      const serviceSigner = await Signer.generate()
+      const server = createServer({
+        id: serviceSigner,
+        service,
+        codec: CAR.inbound,
+        validateAuthorization,
+      })
+
+      const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
+        serviceConf: await mockServiceConf(server),
+      })
+
+      const auths = await createAuthorization({
+        account,
+        service: serviceSigner,
+        agent: alice.agent.issuer
+      })
+      await alice.agent.addProofs(auths)
+
+      await assert.rejects(
+        alice.capability.subscription.list(account.did()),
+        { message: 'failed subscription/list invocation' }
+      )
+
+      assert(service.subscription.list.called)
+      assert.equal(service.subscription.list.callCount, 1)
+    })
+  })
+})

--- a/packages/w3up-client/test/capability/usage.test.js
+++ b/packages/w3up-client/test/capability/usage.test.js
@@ -1,0 +1,96 @@
+import assert from 'assert'
+import { create as createServer, provide } from '@ucanto/server'
+import * as CAR from '@ucanto/transport/car'
+import * as Signer from '@ucanto/principal/ed25519'
+import * as UsageCapabilities from '@web3-storage/capabilities/usage'
+import { AgentData } from '@web3-storage/access/agent'
+import { mockService, mockServiceConf } from '../helpers/mocks.js'
+import { Client } from '../../src/client.js'
+import { validateAuthorization } from '../helpers/utils.js'
+
+describe('UsageClient', () => {
+  describe('report', () => {
+    it('should fetch usage report', async () => {
+      const service = mockService({
+        usage: {
+          report: provide(UsageCapabilities.report, () => {
+            return { ok: { [report.provider]: report } }
+          }),
+        },
+      })
+
+      const server = createServer({
+        id: await Signer.generate(),
+        service,
+        codec: CAR.inbound,
+        validateAuthorization,
+      })
+
+      const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
+        serviceConf: await mockServiceConf(server),
+      })
+
+      const space = await alice.createSpace('test')
+      const auth = await space.createAuthorization(alice)
+      await alice.addSpace(auth)
+
+      const period = { from: new Date(0), to: new Date() }
+      /** @type {import('@web3-storage/capabilities/types').UsageData} */
+      const report = {
+        provider: 'did:web:web3.storage',
+        space: space.did(),
+        size: { initial: 0, final: 0 },
+        period: {
+          from: period.from.toISOString(),
+          to: period.to.toISOString()
+        },
+        events: []
+      }
+
+      const subs = await alice.capability.usage.report(space.did(), period)
+
+      assert(service.usage.report.called)
+      assert.equal(service.usage.report.callCount, 1)
+      assert.deepEqual(subs, { [report.provider]: report })
+    })
+
+    it('should throw on service failure', async () => {
+      const service = mockService({
+        usage: {
+          report: provide(UsageCapabilities.report, ({ capability }) => {
+            return { error: new Error('boom') }
+          }),
+        },
+      })
+
+      const serviceSigner = await Signer.generate()
+      const server = createServer({
+        id: serviceSigner,
+        service,
+        codec: CAR.inbound,
+        validateAuthorization,
+      })
+
+      const alice = new Client(await AgentData.create(), {
+        // @ts-ignore
+        serviceConf: await mockServiceConf(server),
+      })
+
+      const space = await alice.createSpace('test')
+      const auth = await space.createAuthorization(alice)
+      await alice.addSpace(auth)
+
+      await assert.rejects(
+        () => {
+          const period = { from: new Date(), to: new Date() }
+          return alice.capability.usage.report(space.did(), period)
+        },
+        { message: 'failed usage/report invocation' }
+      )
+
+      assert(service.usage.report.called)
+      assert.equal(service.usage.report.callCount, 1)
+    })
+  })
+})

--- a/packages/w3up-client/test/capability/usage.test.js
+++ b/packages/w3up-client/test/capability/usage.test.js
@@ -43,9 +43,9 @@ describe('UsageClient', () => {
         size: { initial: 0, final: 0 },
         period: {
           from: period.from.toISOString(),
-          to: period.to.toISOString()
+          to: period.to.toISOString(),
         },
-        events: []
+        events: [],
       }
 
       const subs = await alice.capability.usage.report(space.did(), period)

--- a/packages/w3up-client/test/helpers/mocks.js
+++ b/packages/w3up-client/test/helpers/mocks.js
@@ -16,6 +16,7 @@ const notImplemented = () => {
  * space: Partial<import('@web3-storage/access/types').Service['space']>
  * ucan: Partial<import('@web3-storage/access/types').Service['ucan']>
  * filecoin: Partial<import('@web3-storage/filecoin-client/types').StorefrontService['filecoin']>
+ * usage: Partial<import('@web3-storage/upload-client/types').Service['usage']>
  * }>} impl
  */
 export function mockService(impl) {
@@ -50,6 +51,9 @@ export function mockService(impl) {
     filecoin: {
       offer: withCallCount(impl.filecoin?.offer ?? notImplemented),
       info: withCallCount(impl.filecoin?.info ?? notImplemented),
+    },
+    usage: {
+      report: withCallCount(impl.usage?.report ?? notImplemented),
     },
   }
 }

--- a/packages/w3up-client/test/helpers/mocks.js
+++ b/packages/w3up-client/test/helpers/mocks.js
@@ -11,6 +11,7 @@ const notImplemented = () => {
  * access: Partial<import('@web3-storage/access/types').Service['access']>
  * provider: Partial<import('@web3-storage/access/types').Service['provider']>
  * store: Partial<import('@web3-storage/upload-client/types').Service['store']>
+ * subscription: Partial<import('@web3-storage/access/types').Service['subscription']>
  * upload: Partial<import('@web3-storage/upload-client/types').Service['upload']>
  * space: Partial<import('@web3-storage/access/types').Service['space']>
  * ucan: Partial<import('@web3-storage/access/types').Service['ucan']>
@@ -31,6 +32,9 @@ export function mockService(impl) {
     },
     space: {
       info: withCallCount(impl.space?.info ?? notImplemented),
+    },
+    subscription: {
+      list: withCallCount(impl.subscription?.list ?? notImplemented),
     },
     access: {
       claim: withCallCount(impl.access?.claim ?? notImplemented),

--- a/packages/w3up-client/test/helpers/utils.js
+++ b/packages/w3up-client/test/helpers/utils.js
@@ -1,1 +1,44 @@
+import * as Server from '@ucanto/server'
+import { UCAN } from '@web3-storage/capabilities'
+import * as Types from '../../src/types.js'
+
 export const validateAuthorization = () => ({ ok: {} })
+
+/**
+ * Utility function that creates a delegation from account to agent and an
+ * attestation from service to proof it. Proofs can be used to invoke any
+ * capability on behalf of the account.
+ *
+ * @param {object} input
+ * @param {Types.UCAN.Signer<Types.AccountDID>} input.account
+ * @param {Types.Signer<Types.DID>} input.service
+ * @param {Types.Signer} input.agent
+ */
+export const createAuthorization = async ({ account, agent, service }) => {
+  // Issue authorization from account DID to agent DID
+  const authorization = await Server.delegate({
+    issuer: account,
+    audience: agent,
+    capabilities: [
+      {
+        with: 'ucan:*',
+        can: '*',
+      },
+    ],
+    expiration: Infinity,
+  })
+
+  const attest = await UCAN.attest
+    .invoke({
+      issuer: service,
+      audience: agent,
+      with: service.did(),
+      nb: {
+        proof: authorization.cid,
+      },
+      expiration: Infinity,
+    })
+    .delegate()
+
+  return [authorization, attest]
+}


### PR DESCRIPTION
Invoking `subscription/list` will retrieve a list of subscriptions for a given account. The list of subscriptions allows us to discover spaces (consumers) that are owned (paid for) by the account. With the list of owned spaces we can make calls to `usage/report` to retrieve and display usage information.

~~TODO: add test to fix coverage in `w3up-client`~~