### PR TITLE
fix: fix export paths for JS files

### DIFF
--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -27,39 +27,39 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/src/index.js"
     },
     "./agent": {
       "types": "./dist/src/agent.d.ts",
-      "import": "./src/agent.js"
+      "import": "./dist/src/agent.js"
     },
     "./space": {
       "types": "./dist/src/space.d.ts",
-      "import": "./src/space.js"
+      "import": "./dist/src/space.js"
     },
     "./provider": {
       "types": "./dist/src/provider.d.ts",
-      "import": "./src/provider.js"
+      "import": "./dist/src/provider.js"
     },
     "./access": {
       "types": "./dist/src/access.d.ts",
-      "import": "./src/access.js"
+      "import": "./dist/src/access.js"
     },
     "./encoding": {
       "types": "./dist/src/encoding.d.ts",
-      "import": "./src/encoding.js"
+      "import": "./dist/src/encoding.js"
     },
     "./types": {
       "types": "./dist/src/types.d.ts",
-      "import": "./src/types.js"
+      "import": "./dist/src/types.js"
     },
     "./drivers/*": {
       "types": "./dist/src/drivers/*.d.ts",
-      "import": "./src/drivers/*.js"
+      "import": "./dist/src/drivers/*.js"
     },
     "./stores/*": {
       "types": "./dist/src/stores/*.d.ts",
-      "import": "./src/stores/*.js"
+      "import": "./dist/src/stores/*.js"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
export paths were changed here: https://github.com/web3-storage/w3up/pull/1059/files#diff-c35cf4a2177e2a86b0f923b4a1682ad2b0344301cffc4f98053a82a1a47d6c1bR28

to point to JS files in the `src` directory, but per the `files` config further down we don't ship those files (and I don't think we should, since it would be duplicative)