### PR TITLE
fix: export new subscription, usage and filecoin clients

### DIFF
--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -21,13 +21,13 @@ import { FilecoinClient } from './capability/filecoin.js'
 export * as Access from './capability/access.js'
 
 export {
-  StoreClient,
-  UploadClient,
-  SpaceClient,
   AccessClient,
+  FilecoinClient,
+  StoreClient,
+  SpaceClient,
   SubscriptionClient,
+  UploadClient,
   UsageClient,
-  FilecoinClient
 }
 
 export class Client extends Base {

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -20,7 +20,15 @@ import { AccessClient } from './capability/access.js'
 import { FilecoinClient } from './capability/filecoin.js'
 export * as Access from './capability/access.js'
 
-export { StoreClient, UploadClient, SpaceClient, AccessClient }
+export {
+  StoreClient,
+  UploadClient,
+  SpaceClient,
+  AccessClient,
+  SubscriptionClient,
+  UsageClient,
+  FilecoinClient
+}
 
 export class Client extends Base {
   /**


### PR DESCRIPTION
This fixes type information on `client.capability.x` and adds the ability to use them separately.