### PR TITLE
ci: .github/workflows/release.yml `docs` job runs when any package is released via release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,10 @@ jobs:
     if: |
       contains(fromJson(needs.release.outputs.paths_released), 'packages/access-client') ||
       contains(fromJson(needs.release.outputs.paths_released), 'packages/capabilities') ||
+      contains(fromJson(needs.release.outputs.paths_released), 'packages/did-mailto') ||
+      contains(fromJson(needs.release.outputs.paths_released), 'packages/upload-client') ||
+      contains(fromJson(needs.release.outputs.paths_released), 'packages/upload-api') ||
       contains(fromJson(needs.release.outputs.paths_released), 'packages/filecoin-client') ||
-      contains(fromJson(needs.release.outputs.paths_released), 'packages/upload-client')
+      contains(fromJson(needs.release.outputs.paths_released), 'packages/filecoin-api') ||
+      contains(fromJson(needs.release.outputs.paths_released), 'packages/w3up-client')
     uses: './.github/workflows/reusable-deploy-docs.yml'


### PR DESCRIPTION
Motivation:
* I think we want to run the docs release more frequently, especially if `w3up-client` is released