### PR TITLE
ci: w3up-client workflow runs when access-client changes

### DIFF
--- a/.github/workflows/w3up-client.yml
+++ b/.github/workflows/w3up-client.yml
@@ -5,11 +5,13 @@ on:
       - main
     paths:
       - 'packages/w3up-client/**'
+      - 'packages/access-client/**'
       - '.github/workflows/w3up-client.yml'
       - 'pnpm-lock.yaml'
   pull_request:
     paths:
       - 'packages/w3up-client/**'
+      - 'packages/access-client/**'
       - '.github/workflows/w3up-client.yml'
       - 'pnpm-lock.yaml'
 jobs:


### PR DESCRIPTION
I think this makes sense because when code in access-client changes, that's going to affect `w3up-client` since `w3up-client` has a workspace-semver dep on access-client.

e.g. I think I would reasonably expect this commit to result in a release-please PR for w3up-client but it didn't. https://github.com/web3-storage/w3up/pull/1157