### PR TITLE
chore: show chores in release notes

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -2,9 +2,9 @@
   "separate-pull-requests": true,
   "bootstrap-sha": "c918ffc59eafa01fbc63d5df11ba621cc1888c64",
   "changelog-sections": [
-    { "type":"feat", "section":"Features", "hidden":false },
-    { "type":"fix", "section":"Fixes", "hidden":false },
-    { "type":"chore", "section":"Other Changes", "hidden":false }
+    { "type": "feat", "section": "Features", "hidden": false },
+    { "type": "fix", "section": "Fixes", "hidden": false },
+    { "type": "chore", "section": "Other Changes", "hidden": false }
   ],
   "packages": {
     "packages/access-client": {},

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,6 +1,11 @@
 {
   "separate-pull-requests": true,
   "bootstrap-sha": "c918ffc59eafa01fbc63d5df11ba621cc1888c64",
+  "changelog-sections": [
+    { "type":"feat", "section":"Features", "hidden":false },
+    { "type":"fix", "section":"Fixes", "hidden":false },
+    { "type":"chore", "section":"Other Changes", "hidden":false }
+  ],
   "packages": {
     "packages/access-client": {},
     "packages/filecoin-api": {},


### PR DESCRIPTION
adding `chore` commits to releases ensures that we have the option of cutting a release from a chore if we want to. with this change release PRs are created after landing any one of chore,fix,feat commit to main.

json schema for release-please config is here: https://github.com/googleapis/release-please/blob/cae5ac0a0203032726a3893bdafe7bde378ae27d/schemas/config.json#L31C10-L31C28

and the per repo config we used in the old monorepo is: https://github.com/web3-storage/web3.storage/blob/ca8b25c3a9466c081dcb3ab9cde733a9567c1c61/.github/workflows/client.yml#L56

License: MIT