### PR TITLE
fix: don't error when we can't figure out a name for a space

### DIFF
--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -346,12 +346,6 @@ export class Agent {
         ? Space.fromDelegation(delegation)
         : Space.fromDelegation(delegation).withName(name)
 
-    if (space.name === '') {
-      throw new Error(
-        'Space has no name, please pass a `name` option to specify it'
-      )
-    }
-
     this.#data.spaces.set(space.did(), { ...space.meta, name: space.name })
 
     await this.addProof(space.delegation)


### PR DESCRIPTION
@juliangruber reported an issue with our documented space creation flow when the exported space access delegation doesn't specify a name and the client doesn't specify one manually:

https://github.com/web3-storage/w3up/issues/1175

I think it's reasonable to require a name for spaces at some level, but I think the access-client API is too low-level for this.