### PR TITLE
fix: storefront events cron with max concurrency

### DIFF
--- a/packages/filecoin-api/package.json
+++ b/packages/filecoin-api/package.json
@@ -159,7 +159,8 @@
     "@ucanto/server": "^9.0.1",
     "@ucanto/transport": "^9.0.0",
     "@web3-storage/capabilities": "workspace:^",
-    "@web3-storage/data-segment": "^4.0.0"
+    "@web3-storage/data-segment": "^4.0.0",
+    "p-map": "^6.0.0"
   },
   "devDependencies": {
     "@ipld/car": "^5.1.1",

--- a/packages/filecoin-api/src/storefront/events.js
+++ b/packages/filecoin-api/src/storefront/events.js
@@ -1,3 +1,4 @@
+import pMap from 'p-map'
 import { Storefront, Aggregator } from '@web3-storage/filecoin-client'
 import * as AggregatorCaps from '@web3-storage/capabilities/filecoin/aggregator'
 
@@ -137,8 +138,9 @@ export const handleCronTick = async (context) => {
     }
   }
   // Update approved pieces from the ones resolved
-  const updatedResponses = await Promise.all(
-    submittedPieces.ok.map((pieceRecord) =>
+  const updatedResponses = await pMap(
+    submittedPieces.ok,
+    (pieceRecord) =>
       updatePiecesWithDeal({
         id: context.id,
         aggregatorId: context.aggregatorId,
@@ -147,7 +149,10 @@ export const handleCronTick = async (context) => {
         taskStore: context.taskStore,
         receiptStore: context.receiptStore,
       })
-    )
+    ,
+    {
+      concurrency: 20
+    }
   )
 
   // Fail if one or more update operations did not succeed.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -260,6 +260,9 @@ importers:
       '@web3-storage/data-segment':
         specifier: ^4.0.0
         version: 4.0.0
+      p-map:
+        specifier: ^6.0.0
+        version: 6.0.0
     devDependencies:
       '@ipld/car':
         specifier: ^5.1.1
@@ -10014,7 +10017,6 @@ packages:
   /p-map@6.0.0:
     resolution: {integrity: sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==}
     engines: {node: '>=16'}
-    dev: true
 
   /p-queue@7.4.1:
     resolution: {integrity: sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==}


### PR DESCRIPTION
Running batches of concurrency 20 in my machine handled in 2.40s a batch of updates. A page query of `4046` in parallel trying to crawl the entire chain was being too much and mostly the CRON would timeout before things getting updated, causing cron to be struggling to move on