### PR TITLE
feat: move aggregate information out of deals in filecoin/info

### DIFF
--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -320,10 +320,23 @@ export interface ProofNotFound extends Ucanto.Failure {
 
 export interface FilecoinInfoSuccess {
   piece: PieceLink
+  aggregates: FilecoinInfoAcceptedAggregate[]
   deals: FilecoinInfoAcceptedDeal[]
 }
+
+export interface FilecoinInfoAcceptedAggregate {
+  /**
+   * Aggregate piece CID.
+   */
+  aggregate: PieceLink
+  /**
+   * Proof the piece is included in the aggregate.
+   */
+  inclusion: InclusionProof
+}
+
 export interface FilecoinInfoAcceptedDeal
-  extends DataAggregationProof,
+  extends Omit<DataAggregationProof, 'inclusion'>,
     DealDetails {
   aggregate: PieceLink
 }

--- a/packages/filecoin-api/src/storefront/events.js
+++ b/packages/filecoin-api/src/storefront/events.js
@@ -148,10 +148,9 @@ export const handleCronTick = async (context) => {
         pieceStore: context.pieceStore,
         taskStore: context.taskStore,
         receiptStore: context.receiptStore,
-      })
-    ,
+      }),
     {
-      concurrency: 20
+      concurrency: 20,
     }
   )
 

--- a/packages/filecoin-api/src/storefront/service.js
+++ b/packages/filecoin-api/src/storefront/service.js
@@ -270,6 +270,7 @@ export const filecoinInfo = async ({ capability }, context) => {
     /** @type {API.UcantoInterface.OkBuilder<API.FilecoinInfoSuccess, API.FilecoinInfoFailure>} */
     const processingResult = Server.ok({
       piece,
+      aggregates: [],
       deals: [],
     })
     return processingResult
@@ -287,27 +288,19 @@ export const filecoinInfo = async ({ capability }, context) => {
   )
 
   if (info.out.error) {
-    return {
-      error: info.out.error,
-    }
+    return info.out
   }
   const deals = Object.entries(info.out.ok.deals || {})
-  if (!deals.length) {
-    // Should not happen if there is `piece/accept` receipt
-    return {
-      error: new Server.Failure(
-        `no deals were obtained for aggregate ${pieceAcceptOut.aggregate} where piece ${piece} is included`
-      ),
-    }
-  }
-
   /** @type {API.UcantoInterface.OkBuilder<API.FilecoinInfoSuccess, API.FilecoinInfoFailure>} */
   const result = Server.ok({
     piece,
+    aggregates: [{
+      aggregate: pieceAcceptOut.aggregate,
+      inclusion: pieceAcceptOut.inclusion
+    }],
     deals: deals.map(([dealId, dealDetails]) => ({
       aggregate: pieceAcceptOut.aggregate,
       provider: dealDetails.provider,
-      inclusion: pieceAcceptOut.inclusion,
       aux: {
         dataType: 0n,
         dataSource: {

--- a/packages/filecoin-api/src/storefront/service.js
+++ b/packages/filecoin-api/src/storefront/service.js
@@ -294,10 +294,12 @@ export const filecoinInfo = async ({ capability }, context) => {
   /** @type {API.UcantoInterface.OkBuilder<API.FilecoinInfoSuccess, API.FilecoinInfoFailure>} */
   const result = Server.ok({
     piece,
-    aggregates: [{
-      aggregate: pieceAcceptOut.aggregate,
-      inclusion: pieceAcceptOut.inclusion
-    }],
+    aggregates: [
+      {
+        aggregate: pieceAcceptOut.aggregate,
+        inclusion: pieceAcceptOut.inclusion,
+      },
+    ],
     deals: deals.map(([dealId, dealDetails]) => ({
       aggregate: pieceAcceptOut.aggregate,
       provider: dealDetails.provider,

--- a/packages/filecoin-api/test/events/aggregator.js
+++ b/packages/filecoin-api/test/events/aggregator.js
@@ -738,7 +738,7 @@ export const test = {
           minPieceInsertedAt: new Date().toISOString(),
         }
         const putAggregateRes = await context.aggregateStore.put(
-          aggregateRecord,
+          aggregateRecord
         )
         assert.ok(putAggregateRes.ok)
 

--- a/packages/filecoin-api/test/services/storefront.js
+++ b/packages/filecoin-api/test/services/storefront.js
@@ -552,8 +552,9 @@ export const test = {
           BigInt(response.out.ok.deals[0].aux.dataSource.dealID),
           dealMetadata.dataSource.dealID
         )
-        assert.ok(response.out.ok.deals[0].inclusion.index)
-        assert.ok(response.out.ok.deals[0].inclusion.subtree)
+        const respAggregate = response.out.ok.aggregates.find(a => a.aggregate.equals(aggregate.link))
+        assert.ok(respAggregate?.inclusion.index)
+        assert.ok(respAggregate?.inclusion.subtree)
       },
       async (context) => {
         /**

--- a/packages/filecoin-api/test/services/storefront.js
+++ b/packages/filecoin-api/test/services/storefront.js
@@ -552,7 +552,9 @@ export const test = {
           BigInt(response.out.ok.deals[0].aux.dataSource.dealID),
           dealMetadata.dataSource.dealID
         )
-        const respAggregate = response.out.ok.aggregates.find(a => a.aggregate.equals(aggregate.link))
+        const respAggregate = response.out.ok.aggregates.find((a) =>
+          a.aggregate.equals(aggregate.link)
+        )
         assert.ok(respAggregate?.inclusion.index)
         assert.ok(respAggregate?.inclusion.subtree)
       },

--- a/packages/filecoin-client/test/storefront.test.js
+++ b/packages/filecoin-client/test/storefront.test.js
@@ -290,6 +290,7 @@ describe('storefront', () => {
 
             return Server.ok({
               piece,
+              aggregates: [],
               deals: [],
             })
           },

--- a/packages/w3up-client/test/capability/filecoin.test.js
+++ b/packages/w3up-client/test/capability/filecoin.test.js
@@ -99,13 +99,15 @@ describe('FilecoinClient', () => {
       /** @type {import('@web3-storage/capabilities/types').FilecoinInfoSuccess} */
       const filecoinAcceptResponse = {
         piece: cargo.link,
-        aggregates: [{
-          aggregate: aggregate.link,
-          inclusion: {
-            subtree: proof.ok[0],
-            index: proof.ok[1],
-          }
-        }],
+        aggregates: [
+          {
+            aggregate: aggregate.link,
+            inclusion: {
+              subtree: proof.ok[0],
+              index: proof.ok[1],
+            },
+          },
+        ],
         deals: [
           {
             aggregate: aggregate.link,

--- a/packages/w3up-client/test/capability/filecoin.test.js
+++ b/packages/w3up-client/test/capability/filecoin.test.js
@@ -99,14 +99,17 @@ describe('FilecoinClient', () => {
       /** @type {import('@web3-storage/capabilities/types').FilecoinInfoSuccess} */
       const filecoinAcceptResponse = {
         piece: cargo.link,
+        aggregates: [{
+          aggregate: aggregate.link,
+          inclusion: {
+            subtree: proof.ok[0],
+            index: proof.ok[1],
+          }
+        }],
         deals: [
           {
             aggregate: aggregate.link,
             provider: 'f1111',
-            inclusion: {
-              subtree: proof.ok[0],
-              index: proof.ok[1],
-            },
             aux: {
               dataType: 0n,
               dataSource: {
@@ -153,7 +156,7 @@ describe('FilecoinClient', () => {
       assert(res.out.ok.deals[0].aggregate.equals(aggregate.link))
       assert(res.out.ok.deals[0].aux.dataSource.dealID)
       assert(res.out.ok.deals[0].provider)
-      assert.deepEqual(res.out.ok.deals[0].inclusion, {
+      assert.deepEqual(res.out.ok.aggregates[0].inclusion, {
         subtree: proof.ok[0],
         index: proof.ok[1],
       })


### PR DESCRIPTION
This PR changes the output of `filecoin/info` such that aggregate information (piece CID and inclusion proof) are moved out of deal info. This means that aggregate info can be accessed before any deals are made and there is no repetition of inclusion proofs in each deal an aggregate is found in.