### PR TITLE
feat!: return allocated bytes in `store/add` receipt

### DIFF
--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -513,14 +513,7 @@ export type UploadAddSuccess = Omit<UploadListItem, 'insertedAt' | 'updatedAt'>
 
 export type UploadGetSuccess = UploadListItem
 
-export type UploadRemoveSuccess = UploadDidRemove | UploadDidNotRemove
-
-export interface UploadDidRemove extends UploadAddSuccess {}
-
-export interface UploadDidNotRemove {
-  root?: undefined
-  shards?: undefined
-}
+export type UploadRemoveSuccess = UploadAddSuccess
 
 export interface UploadListSuccess extends ListResponse<UploadListItem> {}
 

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -444,7 +444,7 @@ export type StoreAddSuccessStatusDone = 'done'
 
 export interface StoreAddSuccessResult {
   /**
-   * Status of the item to store. A "done" status incidactes that it is not
+   * Status of the item to store. A "done" status indicates that it is not
    * necessary to upload the item. An "upload" status indicates that the item
    * should be uploaded to the provided URL.
    */

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -438,18 +438,34 @@ export type StoreRemove = InferInvokedCapability<typeof StoreCaps.remove>
 export type StoreList = InferInvokedCapability<typeof StoreCaps.list>
 
 export type StoreAddSuccess = StoreAddSuccessDone | StoreAddSuccessUpload
-export interface StoreAddSuccessDone {
-  status: 'done'
+
+export type StoreAddSuccessStatusUpload = 'upload'
+export type StoreAddSuccessStatusDone = 'done'
+
+export interface StoreAddSuccessResult {
+  /**
+   * Status of the item to store. A "done" status incidactes that it is not
+   * necessary to upload the item. An "upload" status indicates that the item
+   * should be uploaded to the provided URL.
+   */
+  status: StoreAddSuccessStatusUpload|StoreAddSuccessStatusDone
+  /**
+   * Total bytes allocated in the space to accommodate this stored item.
+   * May be zero if the item is _already_ stored in _this_ space.
+   */
+  allocated: number
+  /** DID of the space this item will be stored in. */
   with: DID
+  /** CID of the item. */
   link: UnknownLink
-  url?: undefined
-  headers?: undefined
 }
 
-export interface StoreAddSuccessUpload {
-  status: 'upload'
-  with: DID
-  link: UnknownLink
+export interface StoreAddSuccessDone extends StoreAddSuccessResult {
+  status: StoreAddSuccessStatusDone
+}
+
+export interface StoreAddSuccessUpload extends StoreAddSuccessResult {
+  status: StoreAddSuccessStatusUpload
   url: ToString<URL>
   headers: Record<string, string>
 }

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -448,7 +448,7 @@ export interface StoreAddSuccessResult {
    * necessary to upload the item. An "upload" status indicates that the item
    * should be uploaded to the provided URL.
    */
-  status: StoreAddSuccessStatusUpload|StoreAddSuccessStatusDone
+  status: StoreAddSuccessStatusUpload | StoreAddSuccessStatusDone
   /**
    * Total bytes allocated in the space to accommodate this stored item.
    * May be zero if the item is _already_ stored in _this_ space.

--- a/packages/eslint-config-w3up/index.js
+++ b/packages/eslint-config-w3up/index.js
@@ -10,7 +10,7 @@ module.exports = {
     EXPERIMENTAL_useProjectService: true,
   },
   rules: {
-    "@typescript-eslint/no-floating-promises": "error",
+    '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/no-unused-vars': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
 

--- a/packages/filecoin-api/test/events/aggregator.js
+++ b/packages/filecoin-api/test/events/aggregator.js
@@ -738,7 +738,7 @@ export const test = {
           minPieceInsertedAt: new Date().toISOString(),
         }
         const putAggregateRes = await context.aggregateStore.put(
-          aggregateRecord,
+          aggregateRecord
         )
         assert.ok(putAggregateRes.ok)
 

--- a/packages/upload-api/src/admin/store/inspect.js
+++ b/packages/upload-api/src/admin/store/inspect.js
@@ -24,9 +24,7 @@ const inspect = async ({ capability }, context) => {
     return { error: new UnknownProvider(capability.with) }
   }
 
-  return {
-    ok: await context.storeTable.inspect(capability.nb.link),
-  }
+  return await context.storeTable.inspect(capability.nb.link)
 }
 
 class UnknownProvider extends Provider.Failure {

--- a/packages/upload-api/src/admin/upload/inspect.js
+++ b/packages/upload-api/src/admin/upload/inspect.js
@@ -24,9 +24,7 @@ const inspect = async ({ capability }, context) => {
     return { error: new UnknownProvider(capability.with) }
   }
 
-  return {
-    ok: await context.uploadTable.inspect(capability.nb.root),
-  }
+  return await context.uploadTable.inspect(capability.nb.root)
 }
 
 class UnknownProvider extends Provider.Failure {

--- a/packages/upload-api/src/store/add.js
+++ b/packages/upload-api/src/store/add.js
@@ -24,7 +24,7 @@ export function storeAddProvider(context) {
       Server.DID.parse(capability.with).did()
     )
     const issuer = invocation.issuer.did()
-    const [allocated, carIsLinkedToAccount, carExists] = await Promise.all([
+    const [allocated, carIsLinkedToSpace, carExists] = await Promise.all([
       allocate(
         {
           capability: {
@@ -42,7 +42,7 @@ export function storeAddProvider(context) {
       return allocated
     }
 
-    if (!carIsLinkedToAccount) {
+    if (!carIsLinkedToSpace) {
       await storeTable.insert({
         space,
         link,
@@ -57,6 +57,7 @@ export function storeAddProvider(context) {
       return {
         ok: {
           status: 'done',
+          allocated: carIsLinkedToSpace ? 0 : size,
           with: space,
           link,
         },
@@ -67,6 +68,7 @@ export function storeAddProvider(context) {
     return {
       ok: {
         status: 'upload',
+        allocated: size,
         with: space,
         link,
         url: url.toString(),

--- a/packages/upload-api/src/store/add.js
+++ b/packages/upload-api/src/store/add.js
@@ -24,7 +24,7 @@ export function storeAddProvider(context) {
       Server.DID.parse(capability.with).did()
     )
     const issuer = invocation.issuer.did()
-    const [allocated, carIsLinkedToSpace, carExists] = await Promise.all([
+    const [allocated, carExists] = await Promise.all([
       allocate(
         {
           capability: {
@@ -33,7 +33,6 @@ export function storeAddProvider(context) {
         },
         context
       ),
-      storeTable.exists(space, link),
       carStoreBucket.has(link),
     ])
 
@@ -42,22 +41,30 @@ export function storeAddProvider(context) {
       return allocated
     }
 
-    if (!carIsLinkedToSpace) {
-      await storeTable.insert({
-        space,
-        link,
-        size,
-        origin,
-        issuer,
-        invocation: invocation.cid,
-      })
+    let allocatedSize = size
+    const res = await storeTable.insert({
+      space,
+      link,
+      size,
+      origin,
+      issuer,
+      invocation: invocation.cid,
+    })
+    if (res.error) {
+      // if the insert failed with conflict then this item has already been
+      // added to the space and there is no allocation change.
+      if (res.error.name === 'RecordKeyConflict') {
+        allocatedSize = 0
+      } else {
+        return res
+      }
     }
 
     if (carExists) {
       return {
         ok: {
           status: 'done',
-          allocated: carIsLinkedToSpace ? 0 : size,
+          allocated: allocatedSize,
           with: space,
           link,
         },
@@ -68,7 +75,7 @@ export function storeAddProvider(context) {
     return {
       ok: {
         status: 'upload',
-        allocated: size,
+        allocated: allocatedSize,
         with: space,
         link,
         url: url.toString(),

--- a/packages/upload-api/src/store/get.js
+++ b/packages/upload-api/src/store/get.js
@@ -1,6 +1,7 @@
 import * as Server from '@ucanto/server'
 import * as Store from '@web3-storage/capabilities/store'
 import * as API from '../types.js'
+import { StoreItemNotFound } from './lib.js'
 
 /**
  * @param {API.StoreServiceContext} context
@@ -14,16 +15,9 @@ export function storeGetProvider(context) {
     }
     const space = Server.DID.parse(capability.with).did()
     const res = await context.storeTable.get(space, link)
-    if (!res) {
-      return {
-        error: {
-          name: 'StoreItemNotFound',
-          message: 'Store item not found',
-        },
-      }
+    if (res.error && res.error.name === 'RecordNotFound') {
+      return Server.error(new StoreItemNotFound(space, link))
     }
-    return {
-      ok: res,
-    }
+    return res
   })
 }

--- a/packages/upload-api/src/store/lib.js
+++ b/packages/upload-api/src/store/lib.js
@@ -1,0 +1,29 @@
+import { Failure } from '@ucanto/server'
+
+export class StoreItemNotFound extends Failure {
+  /**
+   * @param {import('@ucanto/interface').DID} space
+   * @param {import('@ucanto/interface').UnknownLink} link
+   */
+  constructor(space, link) {
+    super()
+    this.space = space
+    this.link = link
+  }
+
+  get name() {
+    return 'StoreItemNotFound'
+  }
+
+  describe() {
+    return `${this.link} not found in ${this.space}`
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      space: this.space,
+      link: { '/': this.link.toString() },
+    }
+  }
+}

--- a/packages/upload-api/src/store/list.js
+++ b/packages/upload-api/src/store/list.js
@@ -10,13 +10,6 @@ export function storeListProvider(context) {
   return Server.provide(Store.list, async ({ capability }) => {
     const { cursor, size, pre } = capability.nb
     const space = Server.DID.parse(capability.with).did()
-
-    return {
-      ok: await context.storeTable.list(space, {
-        size,
-        cursor,
-        pre,
-      }),
-    }
+    return await context.storeTable.list(space, { size, cursor, pre })
   })
 }

--- a/packages/upload-api/src/store/remove.js
+++ b/packages/upload-api/src/store/remove.js
@@ -14,9 +14,7 @@ export function storeRemoveProvider(context) {
 
     const res = await context.storeTable.remove(space, link)
     if (res.error && res.error.name === 'RecordNotFound') {
-      if (res.error.name === 'RecordNotFound') {
-        return Server.error(new StoreItemNotFound(space, link))
-      }
+      return Server.error(new StoreItemNotFound(space, link))
     }
 
     return res

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -440,11 +440,19 @@ export interface RecordKeyConflict extends Failure {
 export interface StoreTable {
   inspect: (link: UnknownLink) => Promise<Result<StoreInspectSuccess, Failure>>
   exists: (space: DID, link: UnknownLink) => Promise<Result<boolean, Failure>>
-  get: (space: DID, link: UnknownLink) => Promise<Result<StoreGetSuccess, RecordNotFound>>
+  get: (
+    space: DID,
+    link: UnknownLink
+  ) => Promise<Result<StoreGetSuccess, RecordNotFound>>
   /** Inserts an item in the table if it does not already exist. */
-  insert: (item: StoreAddInput) => Promise<Result<StoreAddOutput, RecordKeyConflict>>
+  insert: (
+    item: StoreAddInput
+  ) => Promise<Result<StoreAddOutput, RecordKeyConflict>>
   /** Removes an item from the table but fails if the item does not exist. */
-  remove: (space: DID, link: UnknownLink) => Promise<Result<StoreRemoveSuccess, RecordNotFound>>
+  remove: (
+    space: DID,
+    link: UnknownLink
+  ) => Promise<Result<StoreRemoveSuccess, RecordNotFound>>
   list: (
     space: DID,
     options?: ListOptions
@@ -454,14 +462,20 @@ export interface StoreTable {
 export interface UploadTable {
   inspect: (link: UnknownLink) => Promise<Result<UploadInspectSuccess, Failure>>
   exists: (space: DID, root: UnknownLink) => Promise<Result<boolean, Failure>>
-  get: (space: DID, link: UnknownLink) => Promise<Result<UploadGetSuccess, RecordNotFound>>
+  get: (
+    space: DID,
+    link: UnknownLink
+  ) => Promise<Result<UploadGetSuccess, RecordNotFound>>
   /**
    * Inserts an item in the table if it does not already exist or updates an
    * existing item if it does exist.
    */
   upsert: (item: UploadAddInput) => Promise<Result<UploadAddSuccess, Failure>>
   /** Removes an item from the table but fails if the item does not exist. */
-  remove: (space: DID, root: UnknownLink) => Promise<Result<UploadRemoveSuccess, RecordNotFound>>
+  remove: (
+    space: DID,
+    root: UnknownLink
+  ) => Promise<Result<UploadRemoveSuccess, RecordNotFound>>
   list: (
     space: DID,
     options?: ListOptions

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -422,28 +422,50 @@ export interface DudewhereBucket {
   put: (dataCid: string, carCid: string) => Promise<void>
 }
 
+/**
+ * Indicates the requested record was not present in the table.
+ */
+export interface RecordNotFound extends Failure {
+  name: 'RecordNotFound'
+}
+
+/**
+ * Indicates the inserted record key conflicts with an existing key of a record
+ * that already exists in the table.
+ */
+export interface RecordKeyConflict extends Failure {
+  name: 'RecordKeyConflict'
+}
+
 export interface StoreTable {
-  inspect: (link: UnknownLink) => Promise<StoreInspectSuccess>
-  exists: (space: DID, link: UnknownLink) => Promise<boolean>
-  get: (space: DID, link: UnknownLink) => Promise<StoreGetSuccess | undefined>
-  insert: (item: StoreAddInput) => Promise<StoreAddOutput>
-  remove: (space: DID, link: UnknownLink) => Promise<void>
+  inspect: (link: UnknownLink) => Promise<Result<StoreInspectSuccess, Failure>>
+  exists: (space: DID, link: UnknownLink) => Promise<Result<boolean, Failure>>
+  get: (space: DID, link: UnknownLink) => Promise<Result<StoreGetSuccess, RecordNotFound>>
+  /** Inserts an item in the table if it does not already exist. */
+  insert: (item: StoreAddInput) => Promise<Result<StoreAddOutput, RecordKeyConflict>>
+  /** Removes an item from the table but fails if the item does not exist. */
+  remove: (space: DID, link: UnknownLink) => Promise<Result<StoreRemoveSuccess, RecordNotFound>>
   list: (
     space: DID,
     options?: ListOptions
-  ) => Promise<ListResponse<StoreListItem>>
+  ) => Promise<Result<ListResponse<StoreListItem>, Failure>>
 }
 
 export interface UploadTable {
-  inspect: (link: UnknownLink) => Promise<UploadInspectSuccess>
-  exists: (space: DID, root: UnknownLink) => Promise<boolean>
-  get: (space: DID, link: UnknownLink) => Promise<UploadGetSuccess | undefined>
-  insert: (item: UploadAddInput) => Promise<UploadAddSuccess>
-  remove: (space: DID, root: UnknownLink) => Promise<UploadRemoveSuccess | null>
+  inspect: (link: UnknownLink) => Promise<Result<UploadInspectSuccess, Failure>>
+  exists: (space: DID, root: UnknownLink) => Promise<Result<boolean, Failure>>
+  get: (space: DID, link: UnknownLink) => Promise<Result<UploadGetSuccess, RecordNotFound>>
+  /**
+   * Inserts an item in the table if it does not already exist or updates an
+   * existing item if it does exist.
+   */
+  upsert: (item: UploadAddInput) => Promise<Result<UploadAddSuccess, Failure>>
+  /** Removes an item from the table but fails if the item does not exist. */
+  remove: (space: DID, root: UnknownLink) => Promise<Result<UploadRemoveSuccess, RecordNotFound>>
   list: (
     space: DID,
     options?: ListOptions
-  ) => Promise<ListResponse<UploadListItem>>
+  ) => Promise<Result<ListResponse<UploadListItem>, Failure>>
 }
 
 export type SpaceInfoSuccess = {

--- a/packages/upload-api/src/upload/add.js
+++ b/packages/upload-api/src/upload/add.js
@@ -30,7 +30,7 @@ export function uploadAddProvider(context) {
 
     const [res] = await Promise.all([
       // Store in Database
-      uploadTable.insert({
+      uploadTable.upsert({
         space,
         root,
         shards,
@@ -40,7 +40,7 @@ export function uploadAddProvider(context) {
       writeDataCidToCarCidsMapping(dudewhereBucket, root, shards),
     ])
 
-    return { ok: res }
+    return res
   })
 }
 

--- a/packages/upload-api/src/upload/get.js
+++ b/packages/upload-api/src/upload/get.js
@@ -1,6 +1,7 @@
 import * as Server from '@ucanto/server'
 import * as Upload from '@web3-storage/capabilities/upload'
 import * as API from '../types.js'
+import { UploadNotFound } from './lib.js'
 
 /**
  * @param {API.UploadServiceContext} context
@@ -14,16 +15,9 @@ export function uploadGetProvider(context) {
     }
     const space = Server.DID.parse(capability.with).did()
     const res = await context.uploadTable.get(space, root)
-    if (!res) {
-      return {
-        error: {
-          name: 'UploadNotFound',
-          message: 'Upload not found',
-        },
-      }
+    if (res.error && res.error.name === 'RecordNotFound') {
+      return Server.error(new UploadNotFound(space, root))
     }
-    return {
-      ok: res,
-    }
+    return res
   })
 }

--- a/packages/upload-api/src/upload/lib.js
+++ b/packages/upload-api/src/upload/lib.js
@@ -1,0 +1,29 @@
+import { Failure } from '@ucanto/server'
+
+export class UploadNotFound extends Failure {
+  /**
+   * @param {import('@ucanto/interface').DID} space
+   * @param {import('@ucanto/interface').UnknownLink} root
+   */
+  constructor(space, root) {
+    super()
+    this.space = space
+    this.root = root
+  }
+
+  get name() {
+    return 'UploadNotFound'
+  }
+
+  describe() {
+    return `${this.root} not found in ${this.space}`
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      space: this.space,
+      root: { '/': this.root.toString() },
+    }
+  }
+}

--- a/packages/upload-api/src/upload/list.js
+++ b/packages/upload-api/src/upload/list.js
@@ -10,13 +10,6 @@ export function uploadListProvider(context) {
   return Server.provide(Upload.list, async ({ capability }) => {
     const { cursor, size, pre } = capability.nb
     const space = Server.DID.parse(capability.with).did()
-
-    return {
-      ok: await context.uploadTable.list(space, {
-        size,
-        cursor,
-        pre,
-      }),
-    }
+    return await context.uploadTable.list(space, { size, cursor, pre })
   })
 }

--- a/packages/upload-api/src/upload/remove.js
+++ b/packages/upload-api/src/upload/remove.js
@@ -13,10 +13,8 @@ export function uploadRemoveProvider(context) {
     const space = Server.DID.parse(capability.with).did()
 
     const res = await context.uploadTable.remove(space, root)
-    if (res.error) {
-      if (res.error.name === 'RecordNotFound') {
-        return Server.error(new UploadNotFound(space, root))
-      }
+    if (res.error && res.error.name === 'RecordNotFound') {
+      return Server.error(new UploadNotFound(space, root))
     }
 
     return res

--- a/packages/upload-api/src/upload/remove.js
+++ b/packages/upload-api/src/upload/remove.js
@@ -1,6 +1,7 @@
 import * as Server from '@ucanto/server'
 import * as Upload from '@web3-storage/capabilities/upload'
 import * as API from '../types.js'
+import { UploadNotFound } from './lib.js'
 
 /**
  * @param {API.UploadServiceContext} context
@@ -11,10 +12,13 @@ export function uploadRemoveProvider(context) {
     const { root } = capability.nb
     const space = Server.DID.parse(capability.with).did()
 
-    const result = await context.uploadTable.remove(space, root)
-
-    return {
-      ok: result || {},
+    const res = await context.uploadTable.remove(space, root)
+    if (res.error) {
+      if (res.error.name === 'RecordNotFound') {
+        return Server.error(new UploadNotFound(space, root))
+      }
     }
+
+    return res
   })
 }

--- a/packages/upload-api/test/handlers/store.js
+++ b/packages/upload-api/test/handlers/store.js
@@ -321,7 +321,10 @@ export const test = {
     )
   },
 
-  'store/add returns allocated: 0 if already added to space': async (assert, context) => {
+  'store/add returns allocated: 0 if already added to space': async (
+    assert,
+    context
+  ) => {
     const { proof, spaceDid } = await registerSpace(alice, context)
     const connection = connect({
       id: context.id,

--- a/packages/upload-api/test/handlers/store.js
+++ b/packages/upload-api/test/handlers/store.js
@@ -92,9 +92,9 @@ export const test = {
       true
     )
 
-    const { ok: info } = await context.storeTable.inspect(link)
-    assert.equal(info?.spaces.length, 1)
-    assert.equal(info?.spaces[0].did, spaceDid)
+    const { spaces } = Result.unwrap(await context.storeTable.inspect(link))
+    assert.equal(spaces.length, 1)
+    assert.equal(spaces[0].did, spaceDid)
   },
 
   'store/add should allow add the same content to be stored in multiple spaces':
@@ -145,7 +145,7 @@ export const test = {
 
       const { spaces } = Result.unwrap(await context.storeTable.inspect(link))
       assert.equal(spaces.length, 2)
-      const spaceDids = (spaces ?? []).map((space) => space.did)
+      const spaceDids = spaces.map((space) => space.did)
       assert.ok(spaceDids.includes(aliceSpaceDid))
       assert.ok(spaceDids.includes(bobSpaceDid))
     },
@@ -290,7 +290,7 @@ export const test = {
     }
 
     assert.equal(storeAdd.out.ok.status, 'done')
-    assert.equal(storeAdd.out.ok.allocated, data.byteLength)
+    assert.equal(storeAdd.out.ok.allocated, 5)
     assert.equal(storeAdd.out.ok.with, spaceDid)
     assert.deepEqual(storeAdd.out.ok.link.toString(), link.toString())
     // @ts-expect-error making sure it's not an upload status
@@ -353,7 +353,7 @@ export const test = {
     const r0 = await inv0.execute(connection)
 
     assert.equal(r0.out.ok?.status, 'done')
-    assert.equal(r0.out.ok?.allocated, data.byteLength)
+    assert.equal(r0.out.ok?.allocated, 5)
     assert.equal(r0.out.ok?.with, spaceDid)
 
     const inv1 = StoreCapabilities.add.invoke({

--- a/packages/upload-api/test/handlers/store.js
+++ b/packages/upload-api/test/handlers/store.js
@@ -6,6 +6,7 @@ import * as StoreCapabilities from '@web3-storage/capabilities/store'
 import { alice, bob, createSpace, registerSpace } from '../util.js'
 import { Absentee } from '@ucanto/principal'
 import { provisionProvider } from '../helpers/utils.js'
+import * as Result from '../helpers/result.js'
 
 /**
  * @type {API.Tests}
@@ -73,11 +74,7 @@ export const test = {
 
     assert.equal(goodPut.status, 200, await goodPut.text())
 
-    const item = await context.storeTable.get(spaceDid, link)
-
-    if (!item) {
-      return assert.equal(item != null, true)
-    }
+    const item = Result.unwrap(await context.storeTable.get(spaceDid, link))
 
     assert.deepEqual(
       {
@@ -95,9 +92,9 @@ export const test = {
       true
     )
 
-    const { spaces } = await context.storeTable.inspect(link)
-    assert.equal(spaces.length, 1)
-    assert.equal(spaces[0].did, spaceDid)
+    const { ok: info } = await context.storeTable.inspect(link)
+    assert.equal(info?.spaces.length, 1)
+    assert.equal(info?.spaces[0].did, spaceDid)
   },
 
   'store/add should allow add the same content to be stored in multiple spaces':
@@ -146,9 +143,9 @@ export const test = {
 
       assert.ok(bobStoreAdd.out.ok, `Bob failed to store ${link.toString()}`)
 
-      const { spaces } = await context.storeTable.inspect(link)
+      const { spaces } = Result.unwrap(await context.storeTable.inspect(link))
       assert.equal(spaces.length, 2)
-      const spaceDids = spaces.map((space) => space.did)
+      const spaceDids = (spaces ?? []).map((space) => space.did)
       assert.ok(spaceDids.includes(aliceSpaceDid))
       assert.ok(spaceDids.includes(bobSpaceDid))
     },
@@ -299,10 +296,7 @@ export const test = {
     // @ts-expect-error making sure it's not an upload status
     assert.equal(storeAdd.out.ok.url == null, true)
 
-    const item = await context.storeTable.get(spaceDid, link)
-    if (!item) {
-      throw assert.equal(item != null, true, 'should have stored item')
-    }
+    const item = Result.unwrap(await context.storeTable.get(spaceDid, link))
 
     assert.deepEqual(
       {

--- a/packages/upload-api/test/handlers/upload.js
+++ b/packages/upload-api/test/handlers/upload.js
@@ -389,10 +389,7 @@ export const test = {
     )
   },
 
-  'upload/remove fails for non existent upload': async (
-    assert,
-    context
-  ) => {
+  'upload/remove fails for non existent upload': async (assert, context) => {
     const { proof, spaceDid } = await registerSpace(alice, context)
     const connection = connect({
       id: context.id,
@@ -492,7 +489,9 @@ export const test = {
       })
       .execute(connection)
 
-    const { results: spaceAItems } = Result.unwrap(await context.uploadTable.list(spaceDidA))
+    const { results: spaceAItems } = Result.unwrap(
+      await context.uploadTable.list(spaceDidA)
+    )
     assert.equal(
       spaceAItems.some((x) => x.root.toString() === carA.roots[0].toString()),
       false,
@@ -505,7 +504,9 @@ export const test = {
       'SpaceA should have upload for carB.root'
     )
 
-    const { results: spaceBItems } = Result.unwrap(await context.uploadTable.list(spaceDidB))
+    const { results: spaceBItems } = Result.unwrap(
+      await context.uploadTable.list(spaceDidB)
+    )
     assert.equal(
       spaceBItems.some((x) => x.root.toString() === carB.roots[0].toString()),
       false,
@@ -567,7 +568,9 @@ export const test = {
       })
       .execute(connection)
 
-    const { results: resultsAfter } = Result.unwrap(await context.uploadTable.list(spaceDid))
+    const { results: resultsAfter } = Result.unwrap(
+      await context.uploadTable.list(spaceDid)
+    )
     assert.equal(resultsAfter.length, 0)
   },
 

--- a/packages/upload-api/test/helpers/result.js
+++ b/packages/upload-api/test/helpers/result.js
@@ -1,0 +1,22 @@
+export * from '@ucanto/core/result'
+import * as API from '@ucanto/interface'
+
+/**
+ * Returns contained `ok` if result is and throws `error` if result is not ok.
+ *
+ * @template T
+ * @param {API.Result<T, {}>} result
+ * @returns {T}
+ */
+export const unwrap = ({ ok, error }) => {
+  if (error) {
+    throw error
+  } else {
+    return /** @type {T} */ (ok)
+  }
+}
+
+/**
+ * Also expose as `Result.try` which is arguably more clear.
+ */
+export { unwrap as try }

--- a/packages/upload-api/test/storage/store-table.js
+++ b/packages/upload-api/test/storage/store-table.js
@@ -14,9 +14,11 @@ export class StoreTable {
    * @returns {ReturnType<API.StoreTable['insert']>}
    */
   async insert({ space, issuer, invocation, ...output }) {
-    if (this.items.some(i => i.space === space && i.link.equals(output.link))) {
+    if (
+      this.items.some((i) => i.space === space && i.link.equals(output.link))
+    ) {
       return {
-        error: { name: 'RecordKeyConflict', message: 'record key conflict' }
+        error: { name: 'RecordKeyConflict', message: 'record key conflict' },
       }
     }
     this.items.unshift({
@@ -41,7 +43,7 @@ export class StoreTable {
           did: item.space,
           insertedAt: item.insertedAt,
         })),
-      }
+      },
     }
   }
 
@@ -51,7 +53,9 @@ export class StoreTable {
    * @returns {ReturnType<API.StoreTable['get']>}
    */
   async get(space, link) {
-    const item = this.items.find(i => i.space === space && i.link.equals(link))
+    const item = this.items.find(
+      (i) => i.space === space && i.link.equals(link)
+    )
     if (!item) {
       return { error: { name: 'RecordNotFound', message: 'record not found' } }
     }
@@ -64,7 +68,9 @@ export class StoreTable {
    * @returns {ReturnType<API.StoreTable['exists']>}
    */
   async exists(space, link) {
-    const item = this.items.find(i => i.space === space && i.link.equals(link))
+    const item = this.items.find(
+      (i) => i.space === space && i.link.equals(link)
+    )
     return { ok: !!item }
   }
 
@@ -74,11 +80,13 @@ export class StoreTable {
    * @returns {ReturnType<API.StoreTable['remove']>}
    */
   async remove(space, link) {
-    const item = this.items.find(i => i.space === space && i.link.equals(link))
+    const item = this.items.find(
+      (i) => i.space === space && i.link.equals(link)
+    )
     if (!item) {
       return { error: { name: 'RecordNotFound', message: 'record not found' } }
     }
-    this.items = this.items.filter(i => i !== item)
+    this.items = this.items.filter((i) => i !== item)
     return { ok: item }
   }
 
@@ -120,7 +128,7 @@ export class StoreTable {
         after,
         cursor: after,
         results,
-      }
+      },
     }
   }
 }

--- a/packages/upload-api/test/storage/upload-table.js
+++ b/packages/upload-api/test/storage/upload-table.js
@@ -69,11 +69,13 @@ export class UploadTable {
    * @returns {ReturnType<API.UploadTable['remove']>}
    */
   async remove(space, root) {
-    const item = this.items.find(i => i.space === space && i.root.equals(root))
+    const item = this.items.find(
+      (i) => i.space === space && i.root.equals(root)
+    )
     if (!item) {
       return { error: { name: 'RecordNotFound', message: 'record not found' } }
     }
-    this.items = this.items.filter(i => i !== item)
+    this.items = this.items.filter((i) => i !== item)
     return { ok: item }
   }
 
@@ -83,7 +85,9 @@ export class UploadTable {
    * @returns {ReturnType<API.UploadTable['get']>}
    */
   async get(space, root) {
-    const item = this.items.find(i => i.space === space && i.root.equals(root))
+    const item = this.items.find(
+      (i) => i.space === space && i.root.equals(root)
+    )
     if (!item) {
       return { error: { name: 'RecordNotFound', message: 'record not found' } }
     }
@@ -96,7 +100,9 @@ export class UploadTable {
    * @returns {ReturnType<API.UploadTable['exists']>}
    */
   async exists(space, link) {
-    const item = this.items.find(i => i.space === space && i.root.equals(link))
+    const item = this.items.find(
+      (i) => i.space === space && i.root.equals(link)
+    )
     return { ok: !!item }
   }
 
@@ -138,7 +144,7 @@ export class UploadTable {
         after,
         cursor: after,
         results,
-      }
+      },
     }
   }
 }

--- a/packages/upload-api/test/storage/upload-table.js
+++ b/packages/upload-api/test/storage/upload-table.js
@@ -6,31 +6,31 @@ import { parseLink } from '@ucanto/core'
  */
 export class UploadTable {
   constructor() {
-    /** @type {(API.UploadListItem & API.UploadAddInput & { insertedAt: string, updatedAt: string })[]} */
+    /** @type {(API.UploadListItem & API.UploadAddInput)[]} */
     this.items = []
   }
 
   /**
-   *
    * @param {API.UnknownLink} link
-   * @returns {Promise<API.StoreInspectSuccess>}
+   * @returns {ReturnType<API.UploadTable['inspect']>}
    */
   async inspect(link) {
-    const items =
-      this.items?.filter((item) => item.root.toString() === link.toString()) ||
-      []
+    const items = this.items.filter((item) => item.root.equals(link))
     return {
-      spaces: items.map((item) => ({
-        did: item.space,
-        insertedAt: item.insertedAt,
-      })),
+      ok: {
+        spaces: items.map((item) => ({
+          did: item.space,
+          insertedAt: item.insertedAt,
+        })),
+      },
     }
   }
 
   /**
    * @param {API.UploadAddInput} input
+   * @returns {ReturnType<API.UploadTable['upsert']>}
    */
-  async insert({ space, issuer, invocation, root, shards = [] }) {
+  async upsert({ space, issuer, invocation, root, shards = [] }) {
     const time = new Date().toISOString()
     const item = this.items.find(
       (item) => item.space === space && item.root.toString() === root.toString()
@@ -47,7 +47,7 @@ export class UploadTable {
         updatedAt: time,
       })
 
-      return { root, shards: item.shards }
+      return { ok: { root, shards: item.shards } }
     } else {
       this.items.unshift({
         space,
@@ -59,48 +59,51 @@ export class UploadTable {
         updatedAt: time,
       })
 
-      return { root, shards }
+      return { ok: { root, shards } }
     }
   }
 
   /**
    * @param {API.DID} space
    * @param {API.UnknownLink} root
+   * @returns {ReturnType<API.UploadTable['remove']>}
    */
   async remove(space, root) {
-    const item = this.items.find(
-      (item) => item.space === space && item.root.toString() === root.toString()
-    )
-
-    if (item) {
-      this.items.splice(this.items.indexOf(item), 1)
+    const item = this.items.find(i => i.space === space && i.root.equals(root))
+    if (!item) {
+      return { error: { name: 'RecordNotFound', message: 'record not found' } }
     }
-
-    return item || null
+    this.items = this.items.filter(i => i !== item)
+    return { ok: item }
   }
 
   /**
    * @param {API.DID} space
    * @param {API.UnknownLink} root
+   * @returns {ReturnType<API.UploadTable['get']>}
    */
   async get(space, root) {
-    return this.items.find(
-      (item) => item.space === space && item.root.toString() === root.toString()
-    )
+    const item = this.items.find(i => i.space === space && i.root.equals(root))
+    if (!item) {
+      return { error: { name: 'RecordNotFound', message: 'record not found' } }
+    }
+    return { ok: item }
   }
 
   /**
    * @param {API.DID} space
    * @param {API.UnknownLink} link
-   * @returns
+   * @returns {ReturnType<API.UploadTable['exists']>}
    */
   async exists(space, link) {
-    return null != (await this.get(space, link))
+    const item = this.items.find(i => i.space === space && i.root.equals(link))
+    return { ok: !!item }
   }
 
   /**
    * @param {API.DID} space
    * @param {API.ListOptions} options
+   * @returns {ReturnType<API.UploadTable['list']>}
    */
   async list(
     space,
@@ -114,10 +117,7 @@ export class UploadTable {
       .slice(0, size)
 
     if (matches.length === 0) {
-      return {
-        size: 0,
-        results: [],
-      }
+      return { ok: { size: 0, results: [] } }
     }
 
     const first = matches[0]
@@ -132,11 +132,13 @@ export class UploadTable {
       : [`${start + offset}`, `${end + 1 + offset}`, values]
 
     return {
-      size: values.length,
-      before,
-      after,
-      cursor: after,
-      results,
+      ok: {
+        size: values.length,
+        before,
+        after,
+        cursor: after,
+        results,
+      }
     }
   }
 }

--- a/packages/upload-client/test/index.test.js
+++ b/packages/upload-client/test/index.test.js
@@ -51,7 +51,7 @@ describe('uploadFile', () => {
       }),
     ])
 
-    /** @type {import('../src/types.js').StoreAddSuccessUpload} */
+    /** @type {Omit<import('../src/types.js').StoreAddSuccessUpload, 'allocated'>} */
     const res = {
       status: 'upload',
       headers: { 'x-test': 'true' },
@@ -62,13 +62,12 @@ describe('uploadFile', () => {
 
     const service = mockService({
       store: {
-        add: provide(StoreCapabilities.add, ({ invocation }) => {
+        add: provide(StoreCapabilities.add, ({ invocation, capability }) => {
           assert.equal(invocation.issuer.did(), agent.did())
           assert.equal(invocation.capabilities.length, 1)
-          const invCap = invocation.capabilities[0]
-          assert.equal(invCap.can, StoreCapabilities.add.can)
-          assert.equal(invCap.with, space.did())
-          return { ok: res }
+          assert.equal(capability.can, StoreCapabilities.add.can)
+          assert.equal(capability.with, space.did())
+          return { ok: { ...res, allocated: capability.nb.size } }
         }),
       },
       upload: {
@@ -143,7 +142,7 @@ describe('uploadFile', () => {
       }),
     ])
 
-    /** @type {Omit<import('../src/types.js').StoreAddSuccessUpload, 'link'>} */
+    /** @type {Omit<import('../src/types.js').StoreAddSuccessUpload, 'link'|'allocated'>} */
     const res = {
       status: 'upload',
       headers: { 'x-test': 'true' },
@@ -159,6 +158,7 @@ describe('uploadFile', () => {
             link: /** @type {import('../src/types.js').CARLink} */ (
               capability.nb.link
             ),
+            allocated: capability.nb.size,
           },
         })),
       },
@@ -229,7 +229,7 @@ describe('uploadDirectory', () => {
       }),
     ])
 
-    /** @type {Omit<import('../src/types.js').StoreAddSuccessUpload, 'link'>} */
+    /** @type {Omit<import('../src/types.js').StoreAddSuccessUpload, 'link'|'allocated'>} */
     const res = {
       status: 'upload',
       headers: { 'x-test': 'true' },
@@ -251,6 +251,7 @@ describe('uploadDirectory', () => {
               link: /** @type {import('../src/types.js').CARLink} */ (
                 capability.nb.link
               ),
+              allocated: capability.nb.size,
             },
           }
         }),
@@ -323,7 +324,7 @@ describe('uploadDirectory', () => {
       }),
     ])
 
-    /** @type {Omit<import('../src/types.js').StoreAddSuccessUpload, 'link'>} */
+    /** @type {Omit<import('../src/types.js').StoreAddSuccessUpload, 'link'|'allocated'>} */
     const res = {
       status: 'upload',
       headers: { 'x-test': 'true' },
@@ -339,6 +340,7 @@ describe('uploadDirectory', () => {
             link: /** @type {import('../src/types.js').CARLink} */ (
               capability.nb.link
             ),
+            allocated: capability.nb.size,
           },
         })),
       },
@@ -545,7 +547,7 @@ describe('uploadCAR', () => {
       }),
     ])
 
-    /** @type {Omit<import('../src/types.js').StoreAddSuccessUpload, 'link'>} */
+    /** @type {Omit<import('../src/types.js').StoreAddSuccessUpload, 'link'|'allocated'>} */
     const res = {
       status: 'upload',
       headers: { 'x-test': 'true' },
@@ -567,6 +569,7 @@ describe('uploadCAR', () => {
               link: /** @type {import('../src/types.js').CARLink} */ (
                 capability.nb.link
               ),
+              allocated: capability.nb.size,
             },
           }
         }),
@@ -646,7 +649,7 @@ describe('uploadCAR', () => {
       }),
     ])
 
-    /** @type {Omit<import('../src/types.js').StoreAddSuccessUpload, 'link'>} */
+    /** @type {Omit<import('../src/types.js').StoreAddSuccessUpload, 'link'|'allocated'>} */
     const res = {
       status: 'upload',
       headers: { 'x-test': 'true' },
@@ -659,15 +662,15 @@ describe('uploadCAR', () => {
         add: provide(StoreCapabilities.add, ({ capability, invocation }) => {
           assert.equal(invocation.issuer.did(), agent.did())
           assert.equal(invocation.capabilities.length, 1)
-          const invCap = invocation.capabilities[0]
-          assert.equal(invCap.can, StoreCapabilities.add.can)
-          assert.equal(invCap.with, space.did())
+          assert.equal(capability.can, StoreCapabilities.add.can)
+          assert.equal(capability.with, space.did())
           return {
             ok: {
               ...res,
               link: /** @type {import('../src/types.js').CARLink} */ (
                 capability.nb.link
               ),
+              allocated: capability.nb.size,
             },
           }
         }),

--- a/packages/upload-client/test/index.test.js
+++ b/packages/upload-client/test/index.test.js
@@ -411,6 +411,7 @@ describe('uploadDirectory', () => {
                 link: /** @type {import('../src/types.js').CARLink} */ (
                   invocation.capability.nb.link
                 ),
+                allocated: invocation.capability.nb.size,
               },
             }
           }),

--- a/packages/upload-client/test/store.test.js
+++ b/packages/upload-client/test/store.test.js
@@ -33,6 +33,7 @@ describe('Store.add', () => {
       url: 'http://localhost:9200',
       link: car.cid,
       with: space.did(),
+      allocated: car.size,
     }
 
     const service = mockService({
@@ -103,6 +104,7 @@ describe('Store.add', () => {
       url: 'http://localhost:9400', // this bucket always returns a 400
       link: car.cid,
       with: space.did(),
+      allocated: car.size,
     }
 
     const service = mockService({
@@ -156,6 +158,7 @@ describe('Store.add', () => {
       url: 'http://localhost:9500', // this bucket always returns a 500
       link: car.cid,
       with: space.did(),
+      allocated: car.size,
     }
 
     const service = mockService({
@@ -254,6 +257,7 @@ describe('Store.add', () => {
       url: 'http://localhost:9200',
       link: car.cid,
       with: space.did(),
+      allocated: car.size,
     }
 
     const service = mockService({

--- a/packages/w3up-client/test/capability/store.test.js
+++ b/packages/w3up-client/test/capability/store.test.js
@@ -14,7 +14,7 @@ describe('StoreClient', () => {
     it('should store a CAR file', async () => {
       const service = mockService({
         store: {
-          add: provide(StoreCapabilities.add, ({ invocation }) => {
+          add: provide(StoreCapabilities.add, ({ invocation, capability }) => {
             assert.equal(invocation.issuer.did(), alice.agent.did())
             assert.equal(invocation.capabilities.length, 1)
             const invCap = invocation.capabilities[0]
@@ -27,6 +27,7 @@ describe('StoreClient', () => {
                 url: 'http://localhost:9200',
                 link: car.cid,
                 with: space.did(),
+                allocated: capability.nb.size,
               },
             }
           }),

--- a/packages/w3up-client/test/capability/upload.test.js
+++ b/packages/w3up-client/test/capability/upload.test.js
@@ -135,7 +135,7 @@ describe('UploadClient', () => {
               ok: {
                 root: car.roots[0],
                 shards: [car.cid],
-              }
+              },
             }
           }),
         },

--- a/packages/w3up-client/test/capability/upload.test.js
+++ b/packages/w3up-client/test/capability/upload.test.js
@@ -9,7 +9,7 @@ import { mockService, mockServiceConf } from '../helpers/mocks.js'
 import { Client } from '../../src/client.js'
 import { validateAuthorization } from '../helpers/utils.js'
 
-describe('StoreClient', () => {
+describe('UploadClient', () => {
   describe('add', () => {
     it('should register an upload', async () => {
       const car = await randomCAR(128)
@@ -121,6 +121,8 @@ describe('StoreClient', () => {
 
   describe('remove', () => {
     it('should remove an upload', async () => {
+      const car = await randomCAR(128)
+
       const service = mockService({
         upload: {
           remove: provide(UploadCapabilities.remove, ({ invocation }) => {
@@ -129,7 +131,12 @@ describe('StoreClient', () => {
             const invCap = invocation.capabilities[0]
             assert.equal(invCap.can, UploadCapabilities.remove.can)
             assert.equal(invCap.with, alice.currentSpace()?.did())
-            return { ok: {} }
+            return {
+              ok: {
+                root: car.roots[0],
+                shards: [car.cid],
+              }
+            }
           }),
         },
       })
@@ -151,7 +158,7 @@ describe('StoreClient', () => {
       await alice.addSpace(auth)
       await alice.setCurrentSpace(space.did())
 
-      await alice.capability.upload.remove((await randomCAR(128)).roots[0])
+      await alice.capability.upload.remove(car.roots[0])
 
       assert(service.upload.remove.called)
       assert.equal(service.upload.remove.callCount, 1)

--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -30,12 +30,11 @@ describe('Client', () => {
 
       const service = mockService({
         store: {
-          add: provide(StoreCapabilities.add, ({ invocation }) => {
+          add: provide(StoreCapabilities.add, ({ invocation, capability }) => {
             assert.equal(invocation.issuer.did(), alice.agent.did())
             assert.equal(invocation.capabilities.length, 1)
-            const invCap = invocation.capabilities[0]
-            assert.equal(invCap.can, StoreCapabilities.add.can)
-            assert.equal(invCap.with, alice.currentSpace()?.did())
+            assert.equal(capability.can, StoreCapabilities.add.can)
+            assert.equal(capability.with, alice.currentSpace()?.did())
 
             return {
               ok: {
@@ -46,6 +45,7 @@ describe('Client', () => {
                   invocation.capabilities[0].nb?.link
                 ),
                 with: space.did(),
+                allocated: capability.nb.size,
               },
             }
           }),
@@ -126,12 +126,11 @@ describe('Client', () => {
 
       const service = mockService({
         store: {
-          add: provide(StoreCapabilities.add, ({ invocation }) => {
+          add: provide(StoreCapabilities.add, ({ invocation, capability }) => {
             assert.equal(invocation.issuer.did(), alice.agent.did())
             assert.equal(invocation.capabilities.length, 1)
-            const invCap = invocation.capabilities[0]
-            assert.equal(invCap.can, StoreCapabilities.add.can)
-            assert.equal(invCap.with, alice.currentSpace()?.did())
+            assert.equal(capability.can, StoreCapabilities.add.can)
+            assert.equal(capability.with, alice.currentSpace()?.did())
             return {
               ok: {
                 status: 'upload',
@@ -141,6 +140,7 @@ describe('Client', () => {
                   invocation.capabilities[0].nb?.link
                 ),
                 with: space.did(),
+                allocated: capability.nb.size,
               },
             }
           }),
@@ -204,12 +204,11 @@ describe('Client', () => {
 
       const service = mockService({
         store: {
-          add: provide(StoreCapabilities.add, ({ invocation }) => {
+          add: provide(StoreCapabilities.add, ({ invocation, capability }) => {
             assert.equal(invocation.issuer.did(), alice.agent.did())
             assert.equal(invocation.capabilities.length, 1)
-            const invCap = invocation.capabilities[0]
-            assert.equal(invCap.can, StoreCapabilities.add.can)
-            assert.equal(invCap.with, space.did())
+            assert.equal(capability.can, StoreCapabilities.add.can)
+            assert.equal(capability.with, space.did())
             return {
               ok: {
                 status: 'upload',
@@ -219,6 +218,7 @@ describe('Client', () => {
                   invocation.capabilities[0].nb?.link
                 ),
                 with: space.did(),
+                allocated: capability.nb.size,
               },
             }
           }),


### PR DESCRIPTION
This PR adds a new field to the `store/add` success result: `allocated: number` - the total bytes allocated in the space to accommodate the stored item, it **may be zero if the item is _already_ stored in _this_ space**.

This allows us to accurately report and bill for items stored in a space. Currently, `store/add` when the item is already stored in the space will cause a new diff to be created, effecitvely counting the same shard multiple times. This could happen because of accidentally uploading the same item, or because of a retry of a big item where some shards were successful.

The following additional changes enable this functionality:

* `StoreTable` and `UploadTable` methods now have return types that are `Result<O, X>` - this allows us to specify and communicate 2 errors `RecordNotFound` and `RecordKeyConflict` (explained in the following bullets).
* In the context of these 2 tables the semantics of `insert` have changed to be more in line with postgres/other DBs - "insert" means add to the DB or fail (with `RecordKeyConflict`) if an item with the same key already exists.
    * We can satisfy this constraint in dynamodb with [condition expressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html#Expressions.ConditionExpressions.PreventingOverwrites) or [`ReturnValues`](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html#DDB-PutItem-request-ReturnValues).
* In the `UploadTable` I've renamed `insert` to `upsert` since the behaviour in use here is more akin to "update or insert" - aka ["upsert"](https://en.wiktionary.org/wiki/upsert).
* `remove` and `get` now fail with `RecordNotFound` if the item to delete is not available.
    * Again in dynamodb we can satisfy this constraint with condition expressions or `ReturnValues`

