### PR TITLE
fix: use an ArrayBuffer for delegation bits in AgentData

### DIFF
--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -168,7 +168,28 @@ export type AgentDataExport = Pick<
     CIDString,
     {
       meta: DelegationMeta
-      delegation: Array<{ cid: CIDString; bytes: Uint8Array }>
+      delegation: Array<{ cid: CIDString; bytes: ArrayBuffer }>
+    }
+  >
+}
+
+/**
+ * Agent data to be imported after loading from a store.
+ * 
+ * This should be nearly the same as AgentDataExport, and can be
+ * used to reflect changing schemas, eg: moving the type of bytes
+ * from Uint8Array to Arraybuffer
+ */
+export type AgentDataImport = Pick<
+  AgentDataModel,
+  'meta' | 'currentSpace' | 'spaces'
+> & {
+  principal: SignerArchive<DID, SigAlg>
+  delegations: Map<
+    CIDString,
+    {
+      meta: DelegationMeta
+      delegation: Array<{ cid: CIDString; bytes: Uint8Array | ArrayBuffer }>
     }
   >
 }


### PR DESCRIPTION
we noticed that Safari users couldn't log in:

https://github.com/web3-storage/console/issues/46

I traced this down to a seemingly unreported WebKit bug where IndexedDB throws an error when saving Uint8Arrays in an object that uses inline-keys. I don't know these two things don't seem related, but there does seem to be some similar precedent:

https://github.com/dexie/Dexie.js/issues/656#issuecomment-391038490

This change tweaks `AgentData`'s export format to use `ArrayBuffer`s rather than Uint8Arrays, which should solve the issue. I was able to handle coercing back into Uint8Arrays pretty elegantly, and introduced a new `AgentDataImport` type to keep things typesafe.