### PR TITLE
fix: memory usage

### DIFF
--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -78,16 +78,16 @@
     "ipfs-utils": "^9.0.14",
     "multiformats": "^12.1.2",
     "p-retry": "^5.1.2",
-    "parallel-transform-web": "^1.0.0",
+    "parallel-transform-web": "^1.0.1",
     "varint": "^6.0.0"
   },
   "devDependencies": {
     "@types/assert": "^1.5.6",
     "@types/mocha": "^10.0.1",
     "@types/varint": "^6.0.1",
-    "@web3-storage/eslint-config-w3up": "workspace:^",
     "@ucanto/principal": "^9.0.0",
     "@ucanto/server": "^9.0.1",
+    "@web3-storage/eslint-config-w3up": "workspace:^",
     "assert": "^2.0.0",
     "blockstore-core": "^3.0.0",
     "c8": "^7.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -480,8 +480,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.2
       parallel-transform-web:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.1
+        version: 1.0.1
       varint:
         specifier: ^6.0.0
         version: 6.0.0
@@ -10074,8 +10074,8 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /parallel-transform-web@1.0.0:
-    resolution: {integrity: sha512-LgvgIhpDB7f47eI5Wxss4cYQXeWoTCbPr0XVBeFB4icHbrdyEIO8viOoSFRYwufmHobeFbsMuwq+XiWetvwBpA==}
+  /parallel-transform-web@1.0.1:
+    resolution: {integrity: sha512-RtPU/7IuwPZ4ePcqoPxNCpjtaXYOkCVtnhh5tW3O78wy9jqVoV2hQHms17kUeu8DTYoOP+mykFLg2agwVKlwBw==}
     dev: false
 
   /param-case@3.0.4:


### PR DESCRIPTION
Previously `parallel-transform-web` was running up to N transform tasks concurrently, but while those tasks were running it buffered the rest of the stream data internally 🤦 .

This was resolved in https://github.com/alanshaw/parallel-transform-web/pull/1 so just pulling in the latest code here.

I was seeing memory usage in w3cli for a 12GB file grow to ~10GB but now it stays at around at round ~4GB (which is the same usage I see when I remove `parallel-transform-web` and replace it with a regular serial `TransformStream`).