### PR TITLE
feat: dont use ipfs-utils fetch with upload progress by default 

### DIFF
--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./car": "./dist/src/car.js",
+    "./fetch-with-upload-progress": "./dist/src/fetch-with-upload-progress.js",
     "./sharding": "./dist/src/sharding.js",
     "./upload": "./dist/src/upload.js",
     "./store": "./dist/src/store.js",

--- a/packages/upload-client/src/fetch-with-upload-progress.js
+++ b/packages/upload-client/src/fetch-with-upload-progress.js
@@ -4,8 +4,5 @@ import ipfsUtilsFetch from 'ipfs-utils/src/http/fetch.js'
  * @type {import('./types.js').FetchWithUploadProgress}
  */
 export const fetchWithUploadProgress = (url, init) => {
-  if (init && 'readable' in init) {
-    throw new Error('init cannot be readable')
-  }
   return ipfsUtilsFetch.fetch(url, init)
 }

--- a/packages/upload-client/src/fetch-with-upload-progress.js
+++ b/packages/upload-client/src/fetch-with-upload-progress.js
@@ -1,0 +1,11 @@
+import ipfsUtilsFetch from 'ipfs-utils/src/http/fetch.js'
+
+/**
+ * @type {import('./types.js').FetchWithUploadProgress}
+ */
+export const fetchWithUploadProgress = (url, init) => {
+  if (init && 'readable' in init) {
+    throw new Error('init cannot be readable')
+  }
+  return ipfsUtilsFetch.fetch(url, init)
+}

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -1,5 +1,5 @@
 import type {
-  FetchOptions,
+  FetchOptions as IpfsUtilsFetchOptions,
   ProgressStatus as XHRProgressStatus,
 } from 'ipfs-utils/src/types.js'
 import { Link, UnknownLink, Version } from 'multiformats/link'
@@ -44,6 +44,16 @@ import {
   UsageReportSuccess,
   UsageReportFailure,
 } from '@web3-storage/capabilities/types'
+
+type Override<T, R> = Omit<T, keyof R> & R
+
+type FetchOptions = Override<
+  IpfsUtilsFetchOptions,
+  {
+    // `fetch` is a browser API and browsers don't have `Readable`
+    body: Exclude<IpfsUtilsFetchOptions['body'], import('node:stream').Readable>
+  }
+>
 
 export type {
   FetchOptions,
@@ -186,7 +196,13 @@ export interface Connectable {
   connection?: ConnectionView<Service>
 }
 
+export type FetchWithUploadProgress = (
+  url: string,
+  init?: FetchOptions
+) => Promise<Response>
+
 export interface UploadProgressTrackable {
+  fetchWithUploadProgress?: FetchWithUploadProgress
   onUploadProgress?: ProgressFn
 }
 
@@ -210,7 +226,9 @@ export interface RequestOptions
   extends Retryable,
     Abortable,
     Connectable,
-    UploadProgressTrackable {}
+    UploadProgressTrackable {
+  fetch?: typeof globalThis.fetch
+}
 
 export interface ListRequestOptions extends RequestOptions, Pageable {}
 

--- a/packages/upload-client/test/store.test.js
+++ b/packages/upload-client/test/store.test.js
@@ -10,6 +10,7 @@ import { serviceSigner } from './fixtures.js'
 import { randomCAR } from './helpers/random.js'
 import { mockService } from './helpers/mocks.js'
 import { validateAuthorization } from './helpers/utils.js'
+import { fetchWithUploadProgress } from '../src/fetch-with-upload-progress.js'
 
 describe('Store.add', () => {
   it('stores a DAG with the service', async () => {
@@ -71,6 +72,7 @@ describe('Store.add', () => {
           assert(typeof status.loaded === 'number' && status.loaded > 0)
           loaded = status.loaded
         },
+        fetchWithUploadProgress,
       }
     )
 


### PR DESCRIPTION
because importing it in bundled setups breaks, e.g.
* https://github.com/web3-storage/w3up/issues/1183
* https://github.com/web3-storage/w3up/issues/828

I tested this change locally and confirmed that once it's made, upload-client can be relied on by a nextjs project and build successfully
