### PR TITLE
fix: point `main` at files included in the package

### DIFF
--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -12,7 +12,7 @@
   "license": "(Apache-2.0 OR MIT)",
   "type": "module",
   "types": "dist/src/index.d.ts",
-  "main": "src/index.js",
+  "main": "dist/src/index.js",
   "scripts": {
     "attw": "attw --pack .",
     "lint": "tsc --build && eslint '**/*.{js,ts}' && prettier --check '**/*.{js,ts,yml,json}' --ignore-path ../../.gitignore",

--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -12,7 +12,7 @@
   "license": "Apache-2.0 OR MIT",
   "type": "module",
   "types": "dist/src/index.d.ts",
-  "main": "src/index.js",
+  "main": "dist/src/index.js",
   "scripts": {
     "attw": "attw --pack .",
     "lint": "eslint '**/*.{js,ts}' && prettier --check '**/*.{js,ts,yml,json}' --ignore-path ../../.gitignore",


### PR DESCRIPTION
`main` was pointing at `src/index.js` but `src` isn't included in the built package per the `files` key in `package.json`. Fix this!