### PR TITLE
fix: bind globalThis.fetch to globalThis

### DIFF
--- a/packages/upload-client/src/store.js
+++ b/packages/upload-client/src/store.js
@@ -88,7 +88,7 @@ export async function add(
   const responseAddUpload = result.out.ok
 
   const fetchWithUploadProgress =
-    options.fetchWithUploadProgress || options.fetch || globalThis.fetch
+    options.fetchWithUploadProgress || options.fetch || globalThis.fetch.bind(globalThis)
 
   let fetchDidCallUploadProgressCb = false
   const res = await retry(

--- a/packages/upload-client/src/store.js
+++ b/packages/upload-client/src/store.js
@@ -88,7 +88,9 @@ export async function add(
   const responseAddUpload = result.out.ok
 
   const fetchWithUploadProgress =
-    options.fetchWithUploadProgress || options.fetch || globalThis.fetch.bind(globalThis)
+    options.fetchWithUploadProgress ||
+    options.fetch ||
+    globalThis.fetch.bind(globalThis)
 
   let fetchDidCallUploadProgressCb = false
   const res = await retry(


### PR DESCRIPTION
This makes the assigned fetch behave a bit differently than a regular `globalThis.fetch`. a globalThis.fetch will sometimes fail if you do `const me = { fetch }; await me.fetch(url)` but now this bound one won't and will instead behave differently than `globalThis.fetch`.

I think the difference in behavior doesn't matter too much because we just use the assigned fetch right away without passing it along or calling it in such a way that we'd change the default behavior of function calling where `this` is `globalThis` in a way that all `fetch` i've encountered can work with.