### PR TITLE
feat: expose OwnedSpace and SharedSpace from access-client

### DIFF
--- a/packages/access-client/src/space.js
+++ b/packages/access-client/src/space.js
@@ -133,7 +133,7 @@ const toCapabilities = (allow) => {
  * Represents an owned space, meaning a space for which we have a private key
  * and consequently have full authority over.
  */
-class OwnedSpace {
+export class OwnedSpace {
   /**
    * @param {Model} model
    */
@@ -290,7 +290,7 @@ export const provision = async (space, { proofs, agent }) => {
  * Represents a shared space, meaning a space for which we have a delegation
  * and consequently have limited authority over.
  */
-class SharedSpace {
+export class SharedSpace {
   /**
    * @typedef {object} SharedSpaceModel
    * @property {API.SpaceDID} id

--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -66,6 +66,7 @@ export * from '@web3-storage/capabilities/types'
 export * from './errors.js'
 export * from '@web3-storage/did-mailto'
 export type { Agent } from './agent.js'
+export type { OwnedSpace, SharedSpace } from './space.js'
 
 export interface SpaceInfoResult {
   // space did

--- a/packages/w3up-client/src/types.ts
+++ b/packages/w3up-client/src/types.ts
@@ -22,6 +22,8 @@ export type {
   AccountDID,
   ProviderDID,
   SpaceDID,
+  OwnedSpace,
+  SharedSpace,
 } from '@web3-storage/access/types'
 
 export type ProofQuery = Record<Resource, Record<Ability, Unit>>


### PR DESCRIPTION
Not having these available as types is making it hard to build the web console space creation wizard.