### PR TITLE
feat: add remove high level function to client

### DIFF
--- a/packages/w3up-client/README.md
+++ b/packages/w3up-client/README.md
@@ -603,7 +603,7 @@ function remove (
   options: {
     shards?: boolean
   } = {}
-): Promise<Delegation>
+): Promise<void>
 ```
 
 Removes association of a content CID with the space. Optionally, also removes association of CAR shards with space.

--- a/packages/w3up-client/README.md
+++ b/packages/w3up-client/README.md
@@ -608,7 +608,7 @@ function remove (
 
 Removes association of a content CID with the space. Optionally, also removes association of CAR shards with space.
 
-⚠️ Please be aware that all shards will be deleted even if there is another upload(s) that reference same shards, which in turn could corrupt those uploads.
+⚠️ If `shards` option is `true` all shards will be deleted even if there is another upload(s) that reference same shards, which in turn could corrupt those uploads.
 
 ### `getReceipt`
 

--- a/packages/w3up-client/README.md
+++ b/packages/w3up-client/README.md
@@ -394,6 +394,7 @@ sequenceDiagram
   - [`addProof`](#addproof)
   - [`delegations`](#delegations)
   - [`createDelegation`](#createdelegation)
+  - [`remove`](#remove)
   - [`capability.access.authorize`](#capabilityaccessauthorize)
   - [`capability.access.claim`](#capabilityaccessclaim)
   - [`capability.space.info`](#capabilityspaceinfo)
@@ -593,6 +594,21 @@ function createDelegation (
 ```
 
 Create a delegation to the passed audience for the given abilities with the _current_ space as the resource.
+
+### `remove`
+
+```ts
+function remove (
+  contentCID?: CID
+  options: {
+    shards?: boolean
+  } = {}
+): Promise<Delegation>
+```
+
+Removes association of a content CID with the space. Optionally, also removes association of CAR shards with space.
+
+⚠️ Please be aware that all shards will be deleted even if there is another upload(s) that reference same shards, which in turn could corrupt those uploads.
 
 ### `getReceipt`
 

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -316,6 +316,9 @@ export class Client extends Base {
    * Removes association of a content CID with the space. Optionally, also removes
    * association of CAR shards with space.
    *
+   * ⚠️ Please be aware that all shards will be deleted even if there is another upload(s) that
+   * reference same shards, which in turn could corrupt those uploads.
+   *
    * @param {import('multiformats').UnknownLink} contentCID
    * @param {object} [options]
    * @param {boolean} [options.shards]

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -316,7 +316,7 @@ export class Client extends Base {
    * Removes association of a content CID with the space. Optionally, also removes
    * association of CAR shards with space.
    *
-   * ⚠️ Please be aware that all shards will be deleted even if there is another upload(s) that
+   * ⚠️ If `shards` option is `true` all shards will be deleted even if there is another upload(s) that
    * reference same shards, which in turn could corrupt those uploads.
    *
    * @param {import('multiformats').UnknownLink} contentCID

--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -612,13 +612,10 @@ describe('Client', () => {
 
       const service = mockService({
         upload: {
-          // @ts-expect-error root should be a link
           get: provide(UploadCapabilities.get, ({ invocation }) => {
-            return {
-              ok: {
-                root: undefined,
-              },
-            }
+            return error(
+              new StoreItemNotFound('did:web:any', uploadedCar.cid)
+            )
           }),
         },
       })

--- a/packages/w3up-client/test/client.test.js
+++ b/packages/w3up-client/test/client.test.js
@@ -613,9 +613,7 @@ describe('Client', () => {
       const service = mockService({
         upload: {
           get: provide(UploadCapabilities.get, ({ invocation }) => {
-            return error(
-              new StoreItemNotFound('did:web:any', uploadedCar.cid)
-            )
+            return error(new StoreItemNotFound('did:web:any', uploadedCar.cid))
           }),
         },
       })


### PR DESCRIPTION
This PR adds high level function for removing to the client. It essentially follows what has been done in the CLI https://github.com/web3-storage/w3cli/blob/main/index.js#L189-L237

We currently provide this feature according to the docs https://web3.storage/docs/how-to/remove/#using-the-js-client-or-cli but it is not there.

It is annoying that we have docs for something that does not exist. Other option would be to change the docs to use low level capabilities, even though that means explaining more to the users what shards are, which I think is not the best direction. 

Two discussion points:
- Not performing this in an atomic operation may lead to inconsistencies, where for instance part of the shards could be removed but then other operations fail... This is also the current behaviour in the CLI. We could return the result of Promise.allSettled if that would be better.
  - but honestly, I think we should consider not facilitating a high level function to client as it is not an atomic op, may have mutations on partial failure, and as pointed out when part of multiple uploads may also be an issue.
- CLI and docs have defaults as implemented here, but I think it would make more sense to delete shards by default in this high level function, any thoughts?

Closes https://github.com/web3-storage/w3up/issues/1246