### PR TITLE
fix: avoid duplicates on aggregator buffer concat

### DIFF
--- a/packages/filecoin-api/src/aggregator/buffer-reducing.js
+++ b/packages/filecoin-api/src/aggregator/buffer-reducing.js
@@ -232,9 +232,15 @@ export async function getBufferedPieces(bufferPieces, bufferStore) {
   let bufferedPieces = []
   for (const b of getBufferRes) {
     if (b.error) return b
-    bufferedPieces = bufferedPieces.concat(b.ok.buffer.pieces || [])
+    for (const piece of b.ok.buffer.pieces) {
+      const isDuplicate = bufferedPieces.some(
+        existingPiece => existingPiece.piece.equals(piece.piece)
+      )
+      if (!isDuplicate) {
+        bufferedPieces.push(piece)
+      }
+    }
   }
-
   bufferedPieces.sort(sortPieces)
 
   return {


### PR DESCRIPTION
While we know that some queues/streams we use are "at least 1 delivery", we have barely seen any duplicate (see https://filecoinproject.slack.com/archives/C02BZPRS9HP/p1704731857750279).

However, when we had a considerable amount of failures and retries, looks like the "at least 1 delivery" primitive got more significant and we actually got some repeated items. This tries to decrease likelihood of repeated items. Of course that, if they actually make their way into different aggregates this won't be effective, but same piece being added in same aggregate should not happen anymore.