### PR TITLE
feat: strictly require nodejs version

### DIFF
--- a/packages/w3up-client/package.json
+++ b/packages/w3up-client/package.json
@@ -178,5 +178,9 @@
       "assert",
       "c8"
     ]
-  }
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "engineStrict": true
 }


### PR DESCRIPTION
This PR adds `engines` and `engineStrict` props to the `package.json` ensuring users are running the lower bound of what we're currently testing on in CI (v18) when installing.