### PR TITLE
feat: re-export Store implementations from w3up-client

### DIFF
--- a/packages/w3up-client/src/stores.js
+++ b/packages/w3up-client/src/stores.js
@@ -1,0 +1,5 @@
+import { StoreMemory } from '@web3-storage/access/stores/store-memory'
+import { StoreIndexedDB } from '@web3-storage/access/stores/store-indexeddb'
+import { StoreConf } from '@web3-storage/access/stores/store-conf'
+
+export { StoreConf, StoreIndexedDB, StoreMemory }


### PR DESCRIPTION
It's useful to be able to use these in code that doesn't want a dependency on `access-client`.