### PR TITLE
fix: allow import memory store in the browser

### DIFF
--- a/packages/w3up-client/README.md
+++ b/packages/w3up-client/README.md
@@ -180,7 +180,7 @@ import * as Signer from '@ucanto/principal/ed25519' // Agents on Node should use
 import { importDAG } from '@ucanto/core/delegation'
 import { CarReader } from '@ipld/car'
 import * as Client from '@web3-storage/w3up-client'
-import { StoreMemory } from '@web3-storage/w3up-client/stores'
+import { StoreMemory } from '@web3-storage/w3up-client/stores/memory'
 
 async function main () {
   // from "bring your own Agent" example in `Creating a client object" section`

--- a/packages/w3up-client/package.json
+++ b/packages/w3up-client/package.json
@@ -69,8 +69,20 @@
       "import": "./dist/src/capability/usage.js"
     },
     "./stores": {
-      "types": "./dist/src/stores.d.ts",
-      "import": "./dist/src/stores.js"
+      "types": "./dist/src/stores/index.d.ts",
+      "import": "./dist/src/stores/index.js"
+    },
+    "./stores/conf": {
+      "types": "./dist/src/stores/conf.d.ts",
+      "import": "./dist/src/stores/conf.js"
+    },
+    "./stores/indexeddb": {
+      "types": "./dist/src/stores/indexeddb.d.ts",
+      "import": "./dist/src/stores/indexeddb.js"
+    },
+    "./stores/memory": {
+      "types": "./dist/src/stores/memory.d.ts",
+      "import": "./dist/src/stores/memory.js"
     },
     "./types": "./dist/src/types.js"
   },

--- a/packages/w3up-client/src/stores.js
+++ b/packages/w3up-client/src/stores.js
@@ -1,5 +1,0 @@
-import { StoreMemory } from '@web3-storage/access/stores/store-memory'
-import { StoreIndexedDB } from '@web3-storage/access/stores/store-indexeddb'
-import { StoreConf } from '@web3-storage/access/stores/store-conf'
-
-export { StoreConf, StoreIndexedDB, StoreMemory }

--- a/packages/w3up-client/src/stores/conf.js
+++ b/packages/w3up-client/src/stores/conf.js
@@ -1,0 +1,1 @@
+export { StoreConf } from '@web3-storage/access/stores/store-conf'

--- a/packages/w3up-client/src/stores/index.js
+++ b/packages/w3up-client/src/stores/index.js
@@ -1,0 +1,5 @@
+import { StoreMemory } from './memory.js'
+import { StoreIndexedDB } from './indexeddb.js'
+import { StoreConf } from './conf.js'
+
+export { StoreConf, StoreIndexedDB, StoreMemory }

--- a/packages/w3up-client/src/stores/indexeddb.js
+++ b/packages/w3up-client/src/stores/indexeddb.js
@@ -1,0 +1,1 @@
+export { StoreIndexedDB } from '@web3-storage/access/stores/store-indexeddb'

--- a/packages/w3up-client/src/stores/memory.js
+++ b/packages/w3up-client/src/stores/memory.js
@@ -1,0 +1,1 @@
+export { StoreMemory } from '@web3-storage/access/stores/store-memory'


### PR DESCRIPTION
`stores.js` was importing code that uses nodejs modules and is not bundleable....

refs https://github.com/web3-storage/w3up/issues/1274#issuecomment-1907561703