### PR TITLE
feat: two more interface tweaks

### DIFF
--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -55,6 +55,9 @@ import type {
   SubscriptionList,
   SubscriptionListSuccess,
   SubscriptionListFailure,
+  PlanSet,
+  PlanSetSuccess,
+  PlanSetFailure,
 } from '@web3-storage/capabilities/types'
 import type { SetRequired } from 'type-fest'
 import { Driver } from './drivers/types.js'
@@ -132,6 +135,7 @@ export interface Service {
   }
   plan: {
     get: ServiceMethod<PlanGet, PlanGetSuccess, PlanGetFailure>
+    set: ServiceMethod<PlanSet, PlanSetSuccess, PlanSetFailure>
   }
 }
 

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -134,6 +134,9 @@ import {
   UsageReportSuccess,
   UsageReportFailure,
   UsageReport,
+  PlanSetSuccess,
+  PlanSetFailure,
+  PlanSet,
 } from '@web3-storage/capabilities/types'
 import * as Capabilities from '@web3-storage/capabilities'
 import { RevocationsStorage } from './types/revocations.js'
@@ -262,6 +265,7 @@ export interface Service extends StorefrontService {
   }
   plan: {
     get: ServiceMethod<PlanGet, PlanGetSuccess, PlanGetFailure>
+    set: ServiceMethod<PlanSet, PlanSetSuccess, PlanSetFailure>
   }
   usage: {
     report: ServiceMethod<UsageReport, UsageReportSuccess, UsageReportFailure>


### PR DESCRIPTION
I'm getting tsc failures in `w3infra/upload-api` because access-client hasn't been updated to incorporate `UnexpectedError` - update access client types so we can ship a new version. While I'm here, add set method to upload-api `Service` type as well.