### PR TITLE
fix: update fr32 lib to support wasm import

### DIFF
--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -75,7 +75,7 @@
     "@ucanto/interface": "^9.0.0",
     "@ucanto/transport": "^9.0.0",
     "@web3-storage/capabilities": "workspace:^",
-    "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.1.1",
+    "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.2.1",
     "ipfs-utils": "^9.0.14",
     "multiformats": "^12.1.2",
     "p-retry": "^5.1.2",

--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -75,7 +75,7 @@
     "@ucanto/interface": "^9.0.0",
     "@ucanto/transport": "^9.0.0",
     "@web3-storage/capabilities": "workspace:^",
-    "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.2.1",
+    "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.3.0",
     "ipfs-utils": "^9.0.14",
     "multiformats": "^12.1.2",
     "p-retry": "^5.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -468,8 +468,8 @@ importers:
         specifier: workspace:^
         version: link:../capabilities
       fr32-sha2-256-trunc254-padded-binary-tree-multihash:
-        specifier: ^3.1.1
-        version: 3.1.1
+        specifier: ^3.2.1
+        version: 3.2.1
       ipfs-utils:
         specifier: ^9.0.14
         version: 9.0.14
@@ -7063,8 +7063,8 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /fr32-sha2-256-trunc254-padded-binary-tree-multihash@3.1.1:
-    resolution: {integrity: sha512-4nYelGDFTB/gvCK2QdbAKyLcir0uELmzsFSBAJmqHI6JktlIickWFOITRINGdKQU6nqkg+7kWu7i80w1QjAW9Q==}
+  /fr32-sha2-256-trunc254-padded-binary-tree-multihash@3.2.1:
+    resolution: {integrity: sha512-wZmNuV698g3Och9QHy8L8VvDOSnoYIk0G2XvFkWUBR3IjCKh8Fc85Hquqi8WL+Rj1TvYrsc0Rx/1HfwzFTcp5Q==}
     dev: false
 
   /fraction.js@4.3.7:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -468,8 +468,8 @@ importers:
         specifier: workspace:^
         version: link:../capabilities
       fr32-sha2-256-trunc254-padded-binary-tree-multihash:
-        specifier: ^3.2.1
-        version: 3.2.1
+        specifier: ^3.3.0
+        version: 3.3.0
       ipfs-utils:
         specifier: ^9.0.14
         version: 9.0.14
@@ -7063,8 +7063,8 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /fr32-sha2-256-trunc254-padded-binary-tree-multihash@3.2.1:
-    resolution: {integrity: sha512-wZmNuV698g3Och9QHy8L8VvDOSnoYIk0G2XvFkWUBR3IjCKh8Fc85Hquqi8WL+Rj1TvYrsc0Rx/1HfwzFTcp5Q==}
+  /fr32-sha2-256-trunc254-padded-binary-tree-multihash@3.3.0:
+    resolution: {integrity: sha512-O11VDxPmPvbQj5eac2BJXyieNacyd+RCMhwOzXQQM/NCI25x3c32YWB4/JwgOWPCpKnNXF6lpK/j0lj7GWOnYQ==}
     dev: false
 
   /fraction.js@4.3.7:


### PR DESCRIPTION
Needs:
- [x] https://github.com/web3-storage/fr32-sha2-256-trunc254-padded-binary-tree-multihash/pull/37 released and updated here
- [x] docs by mistake I pushed the docs into https://github.com/web3-storage/w3up/pull/1295/files 😂  which was already merged

Closes https://github.com/web3-storage/w3up/issues/1273 