### PR TITLE
feat: add support to prepend pieces while buffering to aggregate

### DIFF
--- a/packages/filecoin-api/src/aggregator/api.ts
+++ b/packages/filecoin-api/src/aggregator/api.ts
@@ -328,6 +328,7 @@ export interface AggregateConfig {
   maxAggregateSize: number
   minAggregateSize: number
   minUtilizationFactor: number
+  prependBufferedPieces?: BufferedPiece[]
 }
 
 // Enums

--- a/packages/filecoin-api/src/aggregator/buffer-reducing.js
+++ b/packages/filecoin-api/src/aggregator/buffer-reducing.js
@@ -152,28 +152,33 @@ export async function handleBufferReducingWithoutAggregate({
  * Attempt to build an aggregate with buffered pieces within ranges.
  *
  * @param {BufferedPiece[]} bufferedPieces
- * @param {object} sizes
- * @param {number} sizes.maxAggregateSize
- * @param {number} sizes.minAggregateSize
- * @param {number} sizes.minUtilizationFactor
+ * @param {object} config
+ * @param {number} config.maxAggregateSize
+ * @param {number} config.minAggregateSize
+ * @param {number} config.minUtilizationFactor
+ * @param {BufferedPiece[]} [config.prependBufferedPieces]
  */
-export function aggregatePieces(bufferedPieces, sizes) {
+export function aggregatePieces(bufferedPieces, config) {
+  const transformedBufferedPieces = [
+    ...(config.prependBufferedPieces || []),
+    ...bufferedPieces
+  ]
   // Guarantee buffered pieces total size is bigger than the minimum utilization
-  const bufferUtilizationSize = bufferedPieces.reduce((total, p) => {
+  const bufferUtilizationSize = transformedBufferedPieces.reduce((total, p) => {
     const piece = Piece.fromLink(p.piece)
     total += piece.size
     return total
   }, 0n)
   if (
     bufferUtilizationSize <
-    sizes.maxAggregateSize / sizes.minUtilizationFactor
+    config.maxAggregateSize / config.minUtilizationFactor
   ) {
     return
   }
 
   // Create builder with maximum size and try to fill it up
   const builder = Aggregate.createBuilder({
-    size: Aggregate.Size.from(sizes.maxAggregateSize),
+    size: Aggregate.Size.from(config.maxAggregateSize),
   })
 
   // add pieces to an aggregate until there is no more space, or no more pieces
@@ -182,7 +187,7 @@ export function aggregatePieces(bufferedPieces, sizes) {
   /** @type {BufferedPiece[]} */
   const remainingBufferedPieces = []
 
-  for (const bufferedPiece of bufferedPieces) {
+  for (const bufferedPiece of transformedBufferedPieces) {
     const p = Piece.fromLink(bufferedPiece.piece)
     if (builder.estimate(p).error) {
       remainingBufferedPieces.push(bufferedPiece)
@@ -196,7 +201,7 @@ export function aggregatePieces(bufferedPieces, sizes) {
     BigInt(builder.limit) * BigInt(Index.EntrySize)
 
   // If not enough space return undefined
-  if (totalUsedSpace < BigInt(sizes.minAggregateSize)) {
+  if (totalUsedSpace < BigInt(config.minAggregateSize)) {
     return
   }
 

--- a/packages/filecoin-api/src/aggregator/events.js
+++ b/packages/filecoin-api/src/aggregator/events.js
@@ -114,6 +114,7 @@ export const handleBufferQueueMessage = async (context, records) => {
     maxAggregateSize: context.config.maxAggregateSize,
     minAggregateSize: context.config.minAggregateSize,
     minUtilizationFactor: context.config.minUtilizationFactor,
+    prependBufferedPieces: context.config.prependBufferedPieces
   })
 
   // Store buffered pieces if not enough to do aggregate and re-queue them


### PR DESCRIPTION
We may need to at the implementation level inject pieces in the start of the Aggregate to overcome requirements of Boost when using PoDSI-formatted aggregate, where first bytes can be problematic for SP to grab in the start of the aggregate

This allows implementer to easily pass an array within the lambda context to run, and easily drop it when needed without being hardcoded in the actual lib :)