### PR TITLE
feat: store deliver and confirm on upload-api

### DIFF
--- a/packages/capabilities/src/index.js
+++ b/packages/capabilities/src/index.js
@@ -61,6 +61,7 @@ export const abilitiesAsStrings = [
   Store.remove.can,
   Store.list.can,
   Store.deliver.can,
+  Store.confirm.can,
   Access.access.can,
   Access.authorize.can,
   UCAN.attest.can,

--- a/packages/capabilities/src/index.js
+++ b/packages/capabilities/src/index.js
@@ -60,6 +60,7 @@ export const abilitiesAsStrings = [
   Store.get.can,
   Store.remove.can,
   Store.list.can,
+  Store.deliver.can,
   Access.access.can,
   Access.authorize.can,
   UCAN.attest.can,

--- a/packages/capabilities/src/store.js
+++ b/packages/capabilities/src/store.js
@@ -155,7 +155,27 @@ export const list = capability({
   },
 })
 
-export const all = add.or(remove).or(list)
+/**
+ * Capability can be invoked by a client to notify the service that content bytes were stored,
+ * as well as by the service to confirm a given content bytes were stored.
+ */
+export const deliver = capability({
+  can: 'store/deliver',
+  /**
+   * DID of the (memory) space where content is intended to
+   * be stored.
+   */
+  with: SpaceDID,
+  nb: Schema.struct({
+    /**
+     * CID of the content delivered to the store.
+     */
+    link: Link,
+  }),
+  derives: equalLink,
+})
+
+export const all = add.or(remove).or(list).or(deliver)
 
 // ⚠️ We export imports here so they are not omitted in generated typedes
 // @see https://github.com/microsoft/TypeScript/issues/51548

--- a/packages/capabilities/src/store.js
+++ b/packages/capabilities/src/store.js
@@ -156,8 +156,7 @@ export const list = capability({
 })
 
 /**
- * Capability can be invoked by a client to notify the service that content bytes were stored,
- * as well as by the service to confirm a given content bytes were stored.
+ * Capability can be invoked by a client to notify the service that content bytes were stored.
  */
 export const deliver = capability({
   can: 'store/deliver',
@@ -175,7 +174,26 @@ export const deliver = capability({
   derives: equalLink,
 })
 
-export const all = add.or(remove).or(list).or(deliver)
+/**
+ * Capability can be invoked by the service to confirm a given content bytes were stored.
+ */
+export const confirm = capability({
+  can: 'store/confirm',
+  /**
+   * DID of the (memory) space where content is intended to
+   * be stored.
+   */
+  with: SpaceDID,
+  nb: Schema.struct({
+    /**
+     * CID of the content delivered to the store.
+     */
+    link: Link,
+  }),
+  derives: equalLink,
+})
+
+export const all = add.or(remove).or(list).or(deliver).or(confirm)
 
 // ⚠️ We export imports here so they are not omitted in generated typedes
 // @see https://github.com/microsoft/TypeScript/issues/51548

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -445,6 +445,7 @@ export type StoreAdd = InferInvokedCapability<typeof StoreCaps.add>
 export type StoreGet = InferInvokedCapability<typeof StoreCaps.get>
 export type StoreRemove = InferInvokedCapability<typeof StoreCaps.remove>
 export type StoreList = InferInvokedCapability<typeof StoreCaps.list>
+export type StoreDeliver = InferInvokedCapability<typeof StoreCaps.deliver>
 
 export type StoreAddSuccess = StoreAddSuccessDone | StoreAddSuccessUpload
 
@@ -509,6 +510,9 @@ export interface StoreListItem {
   origin?: UnknownLink
   insertedAt: ISO8601Date
 }
+
+export interface StoreDeliverSuccess {}
+export type StoreDeliverFailure = StoreItemNotFound | Ucanto.Failure
 
 export interface UploadListItem {
   root: UnknownLink
@@ -683,6 +687,7 @@ export type ServiceAbilityArray = [
   StoreGet['can'],
   StoreRemove['can'],
   StoreList['can'],
+  StoreDeliver['can'],
   Access['can'],
   AccessAuthorize['can'],
   UCANAttest['can'],

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -511,7 +511,10 @@ export interface StoreListItem {
   insertedAt: ISO8601Date
 }
 
-export interface StoreDeliverSuccess {}
+export interface StoreDeliverSuccess {
+  link: UnknownLink
+}
+
 export type StoreDeliverFailure = StoreItemNotFound | Ucanto.Failure
 
 export interface UploadListItem {

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -446,6 +446,7 @@ export type StoreGet = InferInvokedCapability<typeof StoreCaps.get>
 export type StoreRemove = InferInvokedCapability<typeof StoreCaps.remove>
 export type StoreList = InferInvokedCapability<typeof StoreCaps.list>
 export type StoreDeliver = InferInvokedCapability<typeof StoreCaps.deliver>
+export type StoreConfirm = InferInvokedCapability<typeof StoreCaps.confirm>
 
 export type StoreAddSuccess = StoreAddSuccessDone | StoreAddSuccessUpload
 
@@ -516,6 +517,12 @@ export interface StoreDeliverSuccess {
 }
 
 export type StoreDeliverFailure = StoreItemNotFound | Ucanto.Failure
+
+export interface StoreConfirmSuccess {
+  link: UnknownLink
+}
+
+export type StoreConfirmFailure = Ucanto.Failure
 
 export interface UploadListItem {
   root: UnknownLink
@@ -691,6 +698,7 @@ export type ServiceAbilityArray = [
   StoreRemove['can'],
   StoreList['can'],
   StoreDeliver['can'],
+  StoreConfirm['can'],
   Access['can'],
   AccessAuthorize['can'],
   UCANAttest['can'],

--- a/packages/capabilities/src/utils.js
+++ b/packages/capabilities/src/utils.js
@@ -61,7 +61,7 @@ export function equal(child, parent, constraint) {
 }
 
 /**
- * @template {Types.ParsedCapability<"store/add"|"store/get"|"store/remove"|"store/deliver", Types.URI<'did:'>, {link?: Types.Link<unknown, number, number, 0|1>}>} T
+ * @template {Types.ParsedCapability<"store/add"|"store/get"|"store/remove"|"store/deliver"|"store/confirm", Types.URI<'did:'>, {link?: Types.Link<unknown, number, number, 0|1>}>} T
  * @param {T} claimed
  * @param {T} delegated
  * @returns {Types.Result<{}, Types.Failure>}

--- a/packages/capabilities/src/utils.js
+++ b/packages/capabilities/src/utils.js
@@ -61,7 +61,7 @@ export function equal(child, parent, constraint) {
 }
 
 /**
- * @template {Types.ParsedCapability<"store/add"|"store/get"|"store/remove", Types.URI<'did:'>, {link?: Types.Link<unknown, number, number, 0|1>}>} T
+ * @template {Types.ParsedCapability<"store/add"|"store/get"|"store/remove"|"store/deliver", Types.URI<'did:'>, {link?: Types.Link<unknown, number, number, 0|1>}>} T
  * @param {T} claimed
  * @param {T} delegated
  * @returns {Types.Result<{}, Types.Failure>}

--- a/packages/upload-api/src/store.js
+++ b/packages/upload-api/src/store.js
@@ -3,6 +3,7 @@ import { storeGetProvider } from './store/get.js'
 import { storeListProvider } from './store/list.js'
 import { storeRemoveProvider } from './store/remove.js'
 import { storeDeliverProvider } from './store/deliver.js'
+import { storeConfirmProvider } from './store/confirm.js'
 import * as API from './types.js'
 
 /**
@@ -15,5 +16,6 @@ export function createService(context) {
     list: storeListProvider(context),
     remove: storeRemoveProvider(context),
     deliver: storeDeliverProvider(context),
+    confirm: storeConfirmProvider(context),
   }
 }

--- a/packages/upload-api/src/store.js
+++ b/packages/upload-api/src/store.js
@@ -2,6 +2,7 @@ import { storeAddProvider } from './store/add.js'
 import { storeGetProvider } from './store/get.js'
 import { storeListProvider } from './store/list.js'
 import { storeRemoveProvider } from './store/remove.js'
+import { storeDeliverProvider } from './store/deliver.js'
 import * as API from './types.js'
 
 /**
@@ -13,5 +14,6 @@ export function createService(context) {
     get: storeGetProvider(context),
     list: storeListProvider(context),
     remove: storeRemoveProvider(context),
+    deliver: storeDeliverProvider(context),
   }
 }

--- a/packages/upload-api/src/store/confirm.js
+++ b/packages/upload-api/src/store/confirm.js
@@ -1,0 +1,24 @@
+import * as Server from '@ucanto/server'
+import * as Store from '@web3-storage/capabilities/store'
+import * as API from '../types.js'
+
+/**
+ * @param {API.Input<Store.confirm>} input
+ * @param {API.StoreServiceContext} context
+ * @returns {Promise<API.Result<API.StoreConfirmSuccess, API.StoreConfirmFailure> | API.JoinBuilder<API.StoreConfirmSuccess>>}
+ */
+export const storeConfirm = async ({ capability }, context) => {
+  const { link } = capability.nb
+  return Server.ok({ link })
+}
+
+/**
+ * @param {API.StoreServiceContext} context
+ * @returns {API.ServiceMethod<API.StoreConfirm, API.StoreConfirmSuccess, API.StoreConfirmFailure>}
+ */
+export function storeConfirmProvider(context) {
+  return Server.provideAdvanced({
+    capability: Store.confirm,
+    handler: (input) => storeConfirm(input, context)
+  })
+}

--- a/packages/upload-api/src/store/deliver.js
+++ b/packages/upload-api/src/store/deliver.js
@@ -1,0 +1,86 @@
+import * as Server from '@ucanto/server'
+import * as Store from '@web3-storage/capabilities/store'
+import * as API from '../types.js'
+import { StoreItemNotFound, QueueOperationFailed } from './lib.js'
+
+/**
+ * @param {API.Input<Store.deliver>} input
+ * @param {API.StoreServiceContext} context
+ * @returns {Promise<API.Result<API.StoreDeliverSuccess, API.StoreDeliverFailure> | API.JoinBuilder<API.StoreDeliverSuccess>>}
+ */
+const accept = async ({ capability }, context) => {
+  const { link } = capability.nb
+  return Server.ok({ link })
+}
+
+/**
+ * Handle invocation from client by checking that bytes were written, and queueing it for
+ * self signing issue.
+ *
+ * @param {API.Input<Store.deliver>} input
+ * @param {API.StoreServiceContext} context
+ * @returns {Promise<API.Result<API.StoreDeliverSuccess, API.StoreDeliverFailure> | API.JoinBuilder<API.StoreDeliverSuccess>>}
+ */
+const enqueue = async ({ capability }, context) => {
+  const { carStoreBucket } = context
+  const { link } = capability.nb
+  const space = Server.DID.parse(capability.with).did()
+
+  const carExists = await carStoreBucket.has(link)
+  if (!carExists) {
+    return Server.error(new StoreItemNotFound(space, link))
+  }
+
+  // Create effect for receipt for self-signed store/deliver from service
+  const [acceptfx] = await Promise.all([
+    Store.deliver
+      .invoke({
+        issuer: context.id,
+        audience: context.id,
+        // @ts-expect-error did:string:string to did:key:key
+        with: context.id.did(),
+        nb: {
+          link
+        },
+        expiration: Infinity,
+      })
+      .delegate(),
+  ])
+
+  // Queue `store/deliver` self invocation
+  const res = await context.storeDeliverQueue.add({
+    link
+  })
+  if (res.error) {
+    return {
+      error: new QueueOperationFailed(res.error.message),
+    }
+  }
+  
+  /** @type {API.OkBuilder<API.StoreDeliverSuccess, API.StoreDeliverFailure>} */
+  const result = Server.ok({ link })
+  return result.join(acceptfx.link())
+}
+
+/**
+ * @param {API.Input<Store.deliver>} input
+ * @param {API.StoreServiceContext} context
+ * @returns {Promise<API.Result<API.StoreDeliverSuccess, API.StoreDeliverFailure> | API.JoinBuilder<API.StoreDeliverSuccess>>}
+ */
+export const storeDeliver = async (input, context) => {
+  // If self issued we accept without verification
+  return context.id.did() === input.capability.with
+    ? accept(input, context)
+    : enqueue(input, context)
+}
+
+/**
+ * @param {API.StoreServiceContext} context
+ * @returns {API.ServiceMethod<API.StoreDeliver, API.StoreDeliverSuccess, API.StoreDeliverFailure>}
+ */
+export function storeDeliverProvider(context) {
+  return Server.provideAdvanced({
+    capability: Store.deliver,
+    handler: (input) => storeDeliver(input, context)
+  })
+}

--- a/packages/upload-api/src/store/deliver.js
+++ b/packages/upload-api/src/store/deliver.js
@@ -35,10 +35,9 @@ const enqueue = async ({ capability }, context) => {
   const [acceptfx] = await Promise.all([
     Store.deliver
       .invoke({
-        issuer: context.id,
-        audience: context.id,
-        // @ts-expect-error did:string:string to did:key:key
-        with: context.id.did(),
+        issuer: context.signer,
+        audience: context.signer,
+        with: context.signer.toDIDKey(),
         nb: {
           link
         },
@@ -69,7 +68,7 @@ const enqueue = async ({ capability }, context) => {
  */
 export const storeDeliver = async (input, context) => {
   // If self issued we accept without verification
-  return context.id.did() === input.capability.with
+  return context.signer.did() === input.capability.with
     ? accept(input, context)
     : enqueue(input, context)
 }

--- a/packages/upload-api/src/store/lib.js
+++ b/packages/upload-api/src/store/lib.js
@@ -27,3 +27,16 @@ export class StoreItemNotFound extends Failure {
     }
   }
 }
+
+export const QueueOperationErrorName = /** @type {const} */ (
+  'QueueOperationFailed'
+)
+export class QueueOperationFailed extends Failure {
+  get reason() {
+    return this.message
+  }
+
+  get name() {
+    return QueueOperationErrorName
+  }
+}

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -280,7 +280,7 @@ export type StoreServiceContext = SpaceServiceContext & {
   /**
    * Service signer
    */
-  id: Signer
+  signer: Signer
   /**
    * Maximum size that may be uploaded for a file.
    */

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -67,6 +67,9 @@ import {
   StoreDeliver,
   StoreDeliverSuccess,
   StoreDeliverFailure,
+  StoreConfirm,
+  StoreConfirmSuccess,
+  StoreConfirmFailure,
   UploadAdd,
   UploadGet,
   UploadAddSuccess,
@@ -171,6 +174,7 @@ export interface Service extends StorefrontService {
     remove: ServiceMethod<StoreRemove, StoreRemoveSuccess, StoreRemoveFailure>
     list: ServiceMethod<StoreList, StoreListSuccess, Failure>
     deliver: ServiceMethod<StoreDeliver, StoreDeliverSuccess, StoreDeliverFailure>
+    confirm: ServiceMethod<StoreConfirm, StoreConfirmSuccess, StoreConfirmFailure>
   }
   upload: {
     add: ServiceMethod<UploadAdd, UploadAddSuccess, Failure>
@@ -296,7 +300,7 @@ export type StoreServiceContext = SpaceServiceContext & {
   /**
    * Queues pieces for deliver self invocation.
    */
-  storeDeliverQueue: StoreDeliverQueue
+  storeConfirmQueue: StoreConfirmQueue
 }
 
 export type UploadServiceContext = ConsumerServiceContext &
@@ -579,9 +583,9 @@ export interface Queue<Message> {
   ) => Promise<Result<Unit, QueueAddError>>
 }
 
-export type StoreDeliverQueue = Queue<StoreDeliverMessage>
+export type StoreConfirmQueue = Queue<StoreConfirmMessage>
 
-export interface StoreDeliverMessage {
+export interface StoreConfirmMessage {
   link: UnknownLink
 }
 

--- a/packages/upload-api/test/handlers/store.js
+++ b/packages/upload-api/test/handlers/store.js
@@ -838,7 +838,7 @@ export const test = {
     assert.equal(storeDeliver.out.error?.name, 'StoreItemNotFound')
   },
 
-  'store/deliver should return receipt with effect with self signed store/deliver task when already stored': async (assert, context) => {
+  'store/deliver should return receipt with effect with self signed store/confirm task when already stored': async (assert, context) => {
     const { proof, spaceDid } = await registerSpace(alice, context)
     const connection = connect({
       id: context.id,
@@ -894,7 +894,7 @@ export const test = {
     assert.ok(storeDeliver.out.ok?.link.equals(link))
 
     // Verify join task CID
-    const joinTask = await StoreCapabilities.deliver
+    const joinTask = await StoreCapabilities.confirm
       .invoke({
         issuer: context.signer,
         audience: context.signer,
@@ -909,7 +909,7 @@ export const test = {
     assert.ok(joinTask.link().equals(storeDeliver.fx.join))
   },
 
-  'store/deliver can be invoked by service to confirm delivery without further effect': async (assert, context) => {
+  'store/confirm can be invoked by service to confirm delivery without further effect': async (assert, context) => {
     // Force signer with did:web
     const signer = await Signer.generate()
     const connection = connect({
@@ -925,7 +925,7 @@ export const test = {
     const link = await CAR.codec.link(data)
 
     // Service signs file delivered 
-    const storeDeliver = await StoreCapabilities.deliver
+    const storeDeliver = await StoreCapabilities.confirm
       .invoke({
         issuer: signer,
         audience: signer,
@@ -936,6 +936,7 @@ export const test = {
       })
       .execute(connection)
 
+    console.log('xxxx', storeDeliver.out.error)
     assert.ok(storeDeliver.out.ok)
     assert.ok(storeDeliver.out.ok?.link.equals(link))
     assert.equal(storeDeliver.fx.join, undefined)

--- a/packages/upload-api/test/helpers/context.js
+++ b/packages/upload-api/test/helpers/context.js
@@ -3,7 +3,7 @@ import {
   getConnection,
   getMockService,
   getStoreImplementations,
-  getQueueImplementations,
+  getQueueImplementations as getFilecoinQueueImplementations,
 } from '@web3-storage/filecoin-api/test/context/service'
 import { CarStoreBucket } from '../storage/car-store-bucket.js'
 import { StoreTable } from '../storage/store-table.js'
@@ -22,6 +22,9 @@ import { confirmConfirmationUrl } from './utils.js'
 import { PlansStorage } from '../storage/plans-storage.js'
 import { UsageStorage } from '../storage/usage-storage.js'
 import { SubscriptionsStorage } from '../storage/subscriptions-storage.js'
+import {
+  getQueueImplementations,
+} from './queue-implementations.js'
 
 /**
  * @param {object} options
@@ -59,10 +62,12 @@ export const createContext = async (
   const queuedMessages = new Map()
   const {
     storefront: { filecoinSubmitQueue, pieceOfferQueue },
-  } = getQueueImplementations(queuedMessages)
+  } = getFilecoinQueueImplementations(queuedMessages)
   const {
     storefront: { pieceStore, receiptStore, taskStore },
   } = getStoreImplementations()
+  const queues = getQueueImplementations(queuedMessages)
+
   const email = Email.debug()
 
   /** @type { import('../../src/types.js').UcantoServerContext } */
@@ -107,6 +112,7 @@ export const createContext = async (
         audience: dealTrackerSigner,
       },
     },
+    storeDeliverQueue: queues.storeDeliverQueue,
     ...createRevocationChecker({ revocationsStorage }),
   }
 

--- a/packages/upload-api/test/helpers/context.js
+++ b/packages/upload-api/test/helpers/context.js
@@ -112,7 +112,7 @@ export const createContext = async (
         audience: dealTrackerSigner,
       },
     },
-    storeDeliverQueue: queues.storeDeliverQueue,
+    storeConfirmQueue: queues.storeConfirmQueue,
     ...createRevocationChecker({ revocationsStorage }),
   }
 

--- a/packages/upload-api/test/helpers/queue-implementations.js
+++ b/packages/upload-api/test/helpers/queue-implementations.js
@@ -1,0 +1,24 @@
+import { Queue } from './queue.js'
+
+/**
+ * @param {Map<string, unknown[]>} queuedMessages
+ */
+export const getQueueImplementations = (
+  queuedMessages,
+  QueueImplementation = Queue
+) => {
+  queuedMessages.set('storeDeliverQueue', [])
+  const storeDeliverQueue = new QueueImplementation({
+    /**
+     * @param {any} message 
+     */
+    onMessage: (message) => {
+      const messages = queuedMessages.get('storeDeliverQueue') || []
+      messages.push(message)
+      queuedMessages.set('storeDeliverQueue', messages)
+    },
+  })
+  return {
+    storeDeliverQueue,
+  }
+}

--- a/packages/upload-api/test/helpers/queue-implementations.js
+++ b/packages/upload-api/test/helpers/queue-implementations.js
@@ -7,18 +7,18 @@ export const getQueueImplementations = (
   queuedMessages,
   QueueImplementation = Queue
 ) => {
-  queuedMessages.set('storeDeliverQueue', [])
-  const storeDeliverQueue = new QueueImplementation({
+  queuedMessages.set('storeConfirmQueue', [])
+  const storeConfirmQueue = new QueueImplementation({
     /**
      * @param {any} message 
      */
     onMessage: (message) => {
-      const messages = queuedMessages.get('storeDeliverQueue') || []
+      const messages = queuedMessages.get('storeConfirmQueue') || []
       messages.push(message)
-      queuedMessages.set('storeDeliverQueue', messages)
+      queuedMessages.set('storeConfirmQueue', messages)
     },
   })
   return {
-    storeDeliverQueue,
+    storeConfirmQueue,
   }
 }

--- a/packages/upload-api/test/helpers/queue.js
+++ b/packages/upload-api/test/helpers/queue.js
@@ -1,0 +1,47 @@
+import * as API from '../../src/types.js'
+
+import { QueueOperationFailed } from '../../src/store/lib.js'
+
+/**
+ * @template T
+ * @implements {API.Queue<T>}
+ */
+export class Queue {
+  /**
+   * @param {object} [options]
+   * @param {(message: T) => void} [options.onMessage]
+   */
+  constructor(options = {}) {
+    /** @type {Set<T>} */
+    this.items = new Set()
+
+    this.onMessage = options.onMessage || (() => {})
+  }
+
+  /**
+   * @param {T} record
+   */
+  async add(record) {
+    this.items.add(record)
+
+    this.onMessage(record)
+    return Promise.resolve({
+      ok: {},
+    })
+  }
+}
+
+/**
+ * @template T
+ * @implements {API.Queue<T>}
+ */
+export class FailingQueue {
+  /**
+   * @param {T} record
+   */
+  async add(record) {
+    return Promise.resolve({
+      error: new QueueOperationFailed('failed to add to queue'),
+    })
+  }
+}


### PR DESCRIPTION
This PR adds `store/deliver` and `store/confirm` capability and implements its handler in the service based on RFC https://github.com/web3-storage/RFC/pull/10 with the queue pattern.

This will allow us to add event hooks as follow up

Also note that client was not implemented due to the current large refactor in the works. So, I will add it once it lands