### PR TITLE
feat: upgrade ucanto/transport to 9.1.0 in all packages to get more verbose errors from HTTP transport on non-ok response

### DIFF
--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -103,7 +103,7 @@
     "@ucanto/core": "^9.0.1",
     "@ucanto/interface": "^9.0.0",
     "@ucanto/principal": "^9.0.0",
-    "@ucanto/transport": "^9.0.0",
+    "@ucanto/transport": "^9.1.0",
     "@ucanto/validator": "^9.0.1",
     "@web3-storage/capabilities": "workspace:^",
     "@web3-storage/did-mailto": "workspace:^",

--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -86,7 +86,7 @@
     "@ucanto/core": "^9.0.1",
     "@ucanto/interface": "^9.0.0",
     "@ucanto/principal": "^9.0.0",
-    "@ucanto/transport": "^9.0.0",
+    "@ucanto/transport": "^9.1.0",
     "@ucanto/validator": "^9.0.1",
     "@web3-storage/data-segment": "^3.2.0"
   },

--- a/packages/filecoin-api/package.json
+++ b/packages/filecoin-api/package.json
@@ -157,7 +157,7 @@
     "@ucanto/core": "^9.0.1",
     "@ucanto/interface": "^9.0.0",
     "@ucanto/server": "^9.0.1",
-    "@ucanto/transport": "^9.0.0",
+    "@ucanto/transport": "^9.1.0",
     "@web3-storage/capabilities": "workspace:^",
     "@web3-storage/data-segment": "^4.0.0",
     "p-map": "^6.0.0"

--- a/packages/filecoin-client/package.json
+++ b/packages/filecoin-client/package.json
@@ -57,7 +57,7 @@
     "@ucanto/client": "^9.0.0",
     "@ucanto/core": "^9.0.1",
     "@ucanto/interface": "^9.0.0",
-    "@ucanto/transport": "^9.0.0",
+    "@ucanto/transport": "^9.1.0",
     "@web3-storage/capabilities": "workspace:^"
   },
   "devDependencies": {

--- a/packages/upload-api/package.json
+++ b/packages/upload-api/package.json
@@ -126,7 +126,7 @@
     "@ucanto/interface": "^9.0.0",
     "@ucanto/principal": "^9.0.0",
     "@ucanto/server": "^9.0.1",
-    "@ucanto/transport": "^9.0.0",
+    "@ucanto/transport": "^9.1.0",
     "@ucanto/validator": "^9.0.1",
     "@web3-storage/access": "workspace:^",
     "@web3-storage/capabilities": "workspace:^",

--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -73,7 +73,7 @@
     "@ipld/unixfs": "^2.1.1",
     "@ucanto/client": "^9.0.0",
     "@ucanto/interface": "^9.0.0",
-    "@ucanto/transport": "^9.0.0",
+    "@ucanto/transport": "^9.1.0",
     "@web3-storage/capabilities": "workspace:^",
     "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.3.0",
     "ipfs-utils": "^9.0.14",

--- a/packages/w3up-client/package.json
+++ b/packages/w3up-client/package.json
@@ -114,7 +114,7 @@
     "@ucanto/core": "^9.0.1",
     "@ucanto/interface": "^9.0.0",
     "@ucanto/principal": "^9.0.0",
-    "@ucanto/transport": "^9.0.0",
+    "@ucanto/transport": "^9.1.0",
     "@web3-storage/access": "workspace:^",
     "@web3-storage/capabilities": "workspace:^",
     "@web3-storage/did-mailto": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -70,8 +70,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       '@ucanto/transport':
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^9.1.0
+        version: 9.1.0
       '@ucanto/validator':
         specifier: ^9.0.1
         version: 9.0.1
@@ -161,8 +161,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       '@ucanto/transport':
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^9.1.0
+        version: 9.1.0
       '@ucanto/validator':
         specifier: ^9.0.1
         version: 9.0.1
@@ -252,8 +252,8 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1
       '@ucanto/transport':
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^9.1.0
+        version: 9.1.0
       '@web3-storage/capabilities':
         specifier: workspace:^
         version: link:../capabilities
@@ -313,8 +313,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       '@ucanto/transport':
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^9.1.0
+        version: 9.1.0
       '@web3-storage/capabilities':
         specifier: workspace:^
         version: link:../capabilities
@@ -383,8 +383,8 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1
       '@ucanto/transport':
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^9.1.0
+        version: 9.1.0
       '@ucanto/validator':
         specifier: ^9.0.1
         version: 9.0.1
@@ -462,8 +462,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       '@ucanto/transport':
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^9.1.0
+        version: 9.1.0
       '@web3-storage/capabilities':
         specifier: workspace:^
         version: link:../capabilities
@@ -550,8 +550,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       '@ucanto/transport':
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^9.1.0
+        version: 9.1.0
       '@web3-storage/access':
         specifier: workspace:^
         version: link:../access-client
@@ -4298,8 +4298,8 @@ packages:
       '@ucanto/principal': 9.0.0
       '@ucanto/validator': 9.0.1
 
-  /@ucanto/transport@9.0.0:
-    resolution: {integrity: sha512-eN9kkhdp5vC8iYSlT+4YeqyLdV+3g4kYLvuDojdR1lqEcJM2/1W8KjGgmGt6dhE7eBlMqD2hqujS1ePPtY2mKw==}
+  /@ucanto/transport@9.1.0:
+    resolution: {integrity: sha512-3pLXEg9YIH0NN1faBh0Xaioxbb2JtPL+4AFtQtmO8LnRyqGnTahZwwaM8XFL5eMBAp0pYDoZaQ6wdMce0t1cAQ==}
     dependencies:
       '@ucanto/core': 9.0.1
       '@ucanto/interface': 9.0.0


### PR DESCRIPTION
Motivation:
* get this commit in w3up packages https://github.com/web3-storage/ucanto/pull/342