### PR TITLE
feat: byo piece hasher

### DIFF
--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -75,7 +75,7 @@
     "@ucanto/interface": "^9.0.0",
     "@ucanto/transport": "^9.1.0",
     "@web3-storage/capabilities": "workspace:^",
-    "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.3.0",
+    "@web3-storage/data-segment": "^5.1.0",
     "ipfs-utils": "^9.0.14",
     "multiformats": "^12.1.2",
     "p-retry": "^5.1.2",

--- a/packages/upload-client/src/index.js
+++ b/packages/upload-client/src/index.js
@@ -1,5 +1,5 @@
 import { Parallel } from 'parallel-transform-web'
-import * as PieceHasher from 'fr32-sha2-256-trunc254-padded-binary-tree-multihash/async'
+import * as PieceHasher from '@web3-storage/data-segment/multihash'
 import * as Link from 'multiformats/link'
 import * as raw from 'multiformats/codecs/raw'
 import * as Store from './store.js'
@@ -123,6 +123,7 @@ async function uploadBlockStream(conf, blocks, options = {}) {
   /** @type {import('./types.js').AnyLink?} */
   let root = null
   const concurrency = options.concurrentRequests ?? CONCURRENT_REQUESTS
+  const hasher = options.pieceHasher ?? PieceHasher
   await blocks
     .pipeThrough(new ShardingStream(options))
     .pipeThrough(
@@ -131,7 +132,7 @@ async function uploadBlockStream(conf, blocks, options = {}) {
         const [cid, piece] = await Promise.all([
           Store.add(conf, bytes, options),
           (async () => {
-            const multihashDigest = await PieceHasher.digest(bytes)
+            const multihashDigest = await hasher.digest(bytes)
             return /** @type {import('@web3-storage/capabilities/types').PieceLink} */ (
               Link.create(raw.code, multihashDigest)
             )

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -2,7 +2,7 @@ import type {
   FetchOptions as IpfsUtilsFetchOptions,
   ProgressStatus as XHRProgressStatus,
 } from 'ipfs-utils/src/types.js'
-import { Link, UnknownLink, Version } from 'multiformats/link'
+import { Link, UnknownLink, Version, MultihashHasher } from 'multiformats'
 import { Block } from '@ipld/unixfs'
 import {
   ServiceMethod,
@@ -44,6 +44,7 @@ import {
   UsageReportSuccess,
   UsageReportFailure,
 } from '@web3-storage/capabilities/types'
+import { code as pieceHashCode } from '@web3-storage/data-segment/multihash'
 
 type Override<T, R> = Omit<T, keyof R> & R
 
@@ -271,6 +272,7 @@ export interface UploadOptions
     ShardStoringOptions,
     UploadProgressTrackable {
   onShardStored?: (meta: CARMetadata) => void
+  pieceHasher?: MultihashHasher<typeof pieceHashCode>
 }
 
 export interface UploadDirectoryOptions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,9 +467,9 @@ importers:
       '@web3-storage/capabilities':
         specifier: workspace:^
         version: link:../capabilities
-      fr32-sha2-256-trunc254-padded-binary-tree-multihash:
-        specifier: ^3.3.0
-        version: 3.3.0
+      '@web3-storage/data-segment':
+        specifier: ^5.1.0
+        version: 5.1.0
       ipfs-utils:
         specifier: ^9.0.14
         version: 9.0.14
@@ -4411,6 +4411,14 @@ packages:
       sync-multihash-sha2: 1.0.0
     dev: true
 
+  /@web3-storage/data-segment@5.1.0:
+    resolution: {integrity: sha512-FYdmtKvNiVz+maZ++k4PdD43rfJW5DeagLpstq2y84CyOKNRBWbHLCZ/Ec5zT9iGI+0WgsCGbpC/WlG0jlrnhA==}
+    dependencies:
+      '@ipld/dag-cbor': 9.0.6
+      multiformats: 11.0.2
+      sync-multihash-sha2: 1.0.0
+    dev: false
+
   /@web3-storage/sigv4@1.0.2:
     resolution: {integrity: sha512-ZUXKK10NmuQgPkqByhb1H3OQxkIM0CIn2BMPhGQw7vQw8WIzrBkk9IJiAVfJ/UVBFrf6uzPbx2lEBLt4diCMnQ==}
     dependencies:
@@ -7062,10 +7070,6 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
     dev: true
-
-  /fr32-sha2-256-trunc254-padded-binary-tree-multihash@3.3.0:
-    resolution: {integrity: sha512-O11VDxPmPvbQj5eac2BJXyieNacyd+RCMhwOzXQQM/NCI25x3c32YWB4/JwgOWPCpKnNXF6lpK/j0lj7GWOnYQ==}
-    dev: false
 
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}


### PR DESCRIPTION
Allows users to bring their own piece hasher. i.e. they can use the faster [fr32-sha2-256-trunc254-padded-binary-tree-multihash](https://github.com/web3-storage/fr32-sha2-256-trunc254-padded-binary-tree-multihash) hasher if their environment allows them to load the WASM.

Switches the client to use the JS implementation by default.

refs https://github.com/web3-storage/w3up/issues/1322