### PR TITLE
feat: api waits for trigger filecoin pipeline from the client

### DIFF
--- a/packages/filecoin-api/package.json
+++ b/packages/filecoin-api/package.json
@@ -159,7 +159,9 @@
     "@ucanto/server": "^9.0.1",
     "@ucanto/transport": "^9.1.0",
     "@web3-storage/capabilities": "workspace:^",
+    "@web3-storage/content-claims": "^4.0.2",
     "@web3-storage/data-segment": "^4.0.0",
+    "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.3.0",
     "p-map": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/filecoin-api/src/aggregator/buffer-reducing.js
+++ b/packages/filecoin-api/src/aggregator/buffer-reducing.js
@@ -184,10 +184,12 @@ export function aggregatePieces(bufferedPieces, config) {
   const remainingBufferedPieces = []
 
   // start by adding prepend buffered pieces if available
-  for (const bufferedPiece of (config.prependBufferedPieces || [])) {
+  for (const bufferedPiece of config.prependBufferedPieces || []) {
     const p = Piece.fromLink(bufferedPiece.piece)
     if (builder.estimate(p).error) {
-      throw new Error('aggregate builder is not able to create aggregates with only prepend buffered pieces')
+      throw new Error(
+        'aggregate builder is not able to create aggregates with only prepend buffered pieces'
+      )
     }
     builder.write(p)
     addedBufferedPieces.push(bufferedPiece)

--- a/packages/filecoin-api/src/aggregator/events.js
+++ b/packages/filecoin-api/src/aggregator/events.js
@@ -114,7 +114,7 @@ export const handleBufferQueueMessage = async (context, records) => {
     maxAggregateSize: context.config.maxAggregateSize,
     minAggregateSize: context.config.minAggregateSize,
     minUtilizationFactor: context.config.minUtilizationFactor,
-    prependBufferedPieces: context.config.prependBufferedPieces
+    prependBufferedPieces: context.config.prependBufferedPieces,
   })
 
   // Store buffered pieces if not enough to do aggregate and re-queue them

--- a/packages/filecoin-api/src/errors.js
+++ b/packages/filecoin-api/src/errors.js
@@ -71,3 +71,36 @@ export class DecodeBlockOperationFailed extends Server.Failure {
     return DecodeBlockOperationErrorName
   }
 }
+
+export const BlobNotFoundErrorName = /** @type {const} */ ('BlobNotFound')
+export class BlobNotFound extends Server.Failure {
+  get reason() {
+    return this.message
+  }
+
+  get name() {
+    return BlobNotFoundErrorName
+  }
+}
+
+export const ComputePieceErrorName = /** @type {const} */ ('ComputePieceFailed')
+export class ComputePieceFailed extends Error {
+  get reason() {
+    return this.message
+  }
+
+  get name() {
+    return ComputePieceErrorName
+  }
+}
+
+export const UnexpectedPieceErrorName = /** @type {const} */ ('UnexpectedPiece')
+export class UnexpectedPiece extends Error {
+  get reason() {
+    return this.message
+  }
+
+  get name() {
+    return UnexpectedPieceErrorName
+  }
+}

--- a/packages/filecoin-api/src/storefront/api.ts
+++ b/packages/filecoin-api/src/storefront/api.ts
@@ -18,6 +18,7 @@ import {
 import {
   Store,
   UpdatableAndQueryableStore,
+  StreammableStore,
   Queue,
   ServiceConfig,
 } from '../types.js'
@@ -29,7 +30,7 @@ export type PieceStore = UpdatableAndQueryableStore<
 >
 export type FilecoinSubmitQueue = Queue<FilecoinSubmitMessage>
 export type PieceOfferQueue = Queue<PieceOfferMessage>
-export type DataStore = Store<UnknownLink, AsyncIterable<Uint8Array>>
+export type DataStore = StreammableStore<UnknownLink, Uint8Array>
 export type TaskStore = Store<UnknownLink, Invocation>
 export type ReceiptStore = Store<UnknownLink, Receipt>
 
@@ -123,8 +124,7 @@ export interface ClaimsClientContext {
    */
   claimsService: {
     invocationConfig: ClaimsInvocationConfig
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    connection: ConnectionView<any>
+    connection: ConnectionView<import('@web3-storage/content-claims/server/service/api').Service>
   }
 }
 

--- a/packages/filecoin-api/src/storefront/api.ts
+++ b/packages/filecoin-api/src/storefront/api.ts
@@ -5,6 +5,9 @@ import type {
   Receipt,
   Invocation,
   Failure,
+  DID,
+  Proof,
+  ConnectionView,
 } from '@ucanto/interface'
 import { PieceLink } from '@web3-storage/data-segment'
 import {
@@ -26,6 +29,7 @@ export type PieceStore = UpdatableAndQueryableStore<
 >
 export type FilecoinSubmitQueue = Queue<FilecoinSubmitMessage>
 export type PieceOfferQueue = Queue<PieceOfferMessage>
+export type DataStore = Store<UnknownLink, AsyncIterable<Uint8Array>>
 export type TaskStore = Store<UnknownLink, Invocation>
 export type ReceiptStore = Store<UnknownLink, Receipt>
 
@@ -76,7 +80,9 @@ export interface ServiceContext {
 }
 
 export interface FilecoinSubmitMessageContext
-  extends Pick<ServiceContext, 'pieceStore'> {}
+  extends Pick<ServiceContext, 'pieceStore'> {
+  dataStore: DataStore
+}
 
 export interface PieceOfferMessageContext {
   /**
@@ -90,6 +96,36 @@ export interface StorefrontClientContext {
    * Storefront own connection to issue receipts.
    */
   storefrontService: ServiceConfig<StorefrontService>
+}
+
+export interface ClaimsInvocationConfig {
+  /**
+   * Signing authority that is issuing the UCAN invocation(s).
+   */
+  issuer: Signer
+  /**
+   * The principal delegated to in the current UCAN.
+   */
+  audience: Principal
+  /**
+   * The resource the invocation applies to.
+   */
+  with: DID
+  /**
+   * Proof(s) the issuer has the capability to perform the action.
+   */
+  proofs?: Proof[]
+}
+
+export interface ClaimsClientContext {
+  /**
+   * Claims own connection to issue claims.
+   */
+  claimsService: {
+    invocationConfig: ClaimsInvocationConfig
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    connection: ConnectionView<any>
+  }
 }
 
 export interface CronContext

--- a/packages/filecoin-api/src/storefront/events.js
+++ b/packages/filecoin-api/src/storefront/events.js
@@ -40,12 +40,12 @@ export const handleFilecoinSubmitMessage = async (context, message) => {
 
   // read and compute piece for content
   // TODO: needs to be hooked with location claims
-  const contentGetRes = await context.dataStore.get(message.content)
-  if (contentGetRes.error) {
-    return { error: new BlobNotFound(contentGetRes.error.message) }
+  const contentStreamRes = await context.dataStore.stream(message.content)
+  if (contentStreamRes.error) {
+    return { error: new BlobNotFound(contentStreamRes.error.message) }
   }
 
-  const computedPieceCid = await computePieceCid(contentGetRes.ok)
+  const computedPieceCid = await computePieceCid(contentStreamRes.ok)
   if (computedPieceCid.error) {
     return computedPieceCid
   }

--- a/packages/filecoin-api/src/storefront/piece.js
+++ b/packages/filecoin-api/src/storefront/piece.js
@@ -1,0 +1,44 @@
+import { Piece } from '@web3-storage/data-segment'
+import * as Hasher from 'fr32-sha2-256-trunc254-padded-binary-tree-multihash'
+import * as Digest from 'multiformats/hashes/digest'
+
+import { ComputePieceFailed } from '../errors.js'
+
+/**
+ * Compute PieceCid for provided async iterable.
+ *
+ * @param {AsyncIterable<Uint8Array>} stream
+ */
+export async function computePieceCid(stream) {
+  /** @type {import('../types.js').PieceLink} */
+  let piece
+  try {
+    const hasher = Hasher.create()
+    for await (const chunk of stream) {
+      hasher.write(chunk)
+    }
+
+    // ⚠️ Because digest size will dependen on the payload (padding)
+    // we have to determine number of bytes needed after we're done
+    // writing payload
+    const digest = new Uint8Array(hasher.multihashByteLength())
+    hasher.digestInto(digest, 0, true)
+
+    // There's no GC (yet) in WASM so you should free up
+    // memory manually once you're done.
+    hasher.free()
+    const multihashDigest = Digest.decode(digest)
+    // @ts-expect-error some properties from PieceDigest are not present in MultihashDigest
+    piece = Piece.fromDigest(multihashDigest)
+  } catch (/** @type {any} */ error) {
+    return {
+      error: new ComputePieceFailed(`failed to compute piece CID for bytes`, {
+        cause: error,
+      }),
+    }
+  }
+
+  return {
+    ok: { piece },
+  }
+}

--- a/packages/filecoin-api/src/storefront/service.js
+++ b/packages/filecoin-api/src/storefront/service.js
@@ -21,6 +21,7 @@ export const filecoinOffer = async ({ capability }, context) => {
   const { piece, content } = capability.nb
 
   // Queue offer for filecoin submission
+  // We need to identify new client here...
   if (!context.options?.skipFilecoinSubmitQueue) {
     // dedupe
     const hasRes = await context.pieceStore.has({ piece })

--- a/packages/filecoin-api/src/types.ts
+++ b/packages/filecoin-api/src/types.ts
@@ -52,6 +52,17 @@ export interface UpdatableStore<RecKey, Rec> extends Store<RecKey, Rec> {
   ) => Promise<Result<Rec, StoreGetError>>
 }
 
+export interface StreammableStore<RecKey, Rec> {
+  /**
+   * Puts a record in the store.
+   */
+  put: (record: Rec) => Promise<Result<Unit, StorePutError>>
+  /**
+   * Gets a record from the store.
+   */
+  stream: (key: RecKey) => Promise<Result<AsyncIterable<Rec>, StoreGetError>>
+}
+
 export interface QueryableStore<RecKey, Rec, Query> extends Store<RecKey, Rec> {
   /**
    * Queries for record matching a given criterium.

--- a/packages/filecoin-api/test/context/mocks.js
+++ b/packages/filecoin-api/test/context/mocks.js
@@ -10,6 +10,7 @@ const notImplemented = () => {
  * piece: Partial<import('../../src/types.js').AggregatorService['piece']>
  * aggregate: Partial<import('../../src/types.js').DealerService['aggregate']>
  * deal: Partial<import('../../src/types.js').DealTrackerService['deal']>
+ * assert: Partial<import('@web3-storage/content-claims/server/service/api').AssertService>
  * }>} impl
  */
 export function mockService(impl) {
@@ -30,6 +31,9 @@ export function mockService(impl) {
     deal: {
       info: withCallParams(impl.deal?.info ?? notImplemented),
     },
+    assert: {
+      equals: withCallParams(impl.assert?.equals ?? notImplemented)
+    }
   }
 }
 

--- a/packages/filecoin-api/test/context/service.js
+++ b/packages/filecoin-api/test/context/service.js
@@ -2,6 +2,7 @@ import * as Client from '@ucanto/client'
 import * as Server from '@ucanto/server'
 import * as CAR from '@ucanto/transport/car'
 
+import { Assert } from '@web3-storage/content-claims/capability'
 import * as StorefrontCaps from '@web3-storage/capabilities/filecoin/storefront'
 import * as AggregatorCaps from '@web3-storage/capabilities/filecoin/aggregator'
 import * as DealerCaps from '@web3-storage/capabilities/filecoin/dealer'
@@ -215,6 +216,13 @@ export function getMockService() {
         },
       }),
     },
+    assert: {
+      equals: Server.provide(Assert.equals, async ({ capability, invocation }) => {
+        return {
+          ok: {}
+        }
+      })
+    }
   })
 }
 

--- a/packages/filecoin-api/test/context/store-implementations.js
+++ b/packages/filecoin-api/test/context/store-implementations.js
@@ -76,6 +76,14 @@ export const getStoreImplementations = (
         return Array.from(items).find((i) => i.ran.link().equals(record))
       },
     }),
+    dataStore: new StoreImplementation({
+      getFn: (
+        /** @type {Set<AsyncIterable<Uint8Array>>} */ items,
+        /** @type {import('@ucanto/interface').UnknownLink} */ record
+      ) => {
+        return Array.from(items).pop()
+      },
+    }),
   },
   aggregator: {
     pieceStore: new StoreImplementation({

--- a/packages/filecoin-api/test/context/store.js
+++ b/packages/filecoin-api/test/context/store.js
@@ -97,6 +97,53 @@ export class Store {
 /**
  * @template K
  * @template V
+ * @implements {API.StreammableStore<K,V>}
+ */
+export class StreammableStore {
+  /**
+   * @param {import('./types.js').StreammableStoreOptions<K, V>} options
+   */
+  constructor(options) {
+    /** @type {Set<V>} */
+    this.items = new Set()
+    this.streamFn = options.streamFn
+  }
+
+  /**
+   * @param {V} record
+   * @returns {Promise<import('@ucanto/interface').Result<{}, StorePutError>>}
+   */
+  async put(record) {
+    this.items.add(record)
+
+    return Promise.resolve({
+      ok: {},
+    })
+  }
+
+  /**
+   * @param {K} item
+   * @returns {Promise<import('@ucanto/interface').Result<AsyncIterable<V>, StoreGetError>>}
+   */
+  async stream(item) {
+    if (!this.streamFn) {
+      throw new Error('get not supported')
+    }
+    const t = this.streamFn(this.items, item)
+    if (!t) {
+      return {
+        error: new RecordNotFound('not found'),
+      }
+    }
+    return {
+      ok: t,
+    }
+  }
+}
+
+/**
+ * @template K
+ * @template V
  * @implements {API.UpdatableStore<K,V>}
  * @extends {Store<K, V>}
  */

--- a/packages/filecoin-api/test/context/types.ts
+++ b/packages/filecoin-api/test/context/types.ts
@@ -6,3 +6,7 @@ export interface StoreOptions<K, V> {
 export interface UpdatableStoreOptions<K, V> extends StoreOptions<K, V> {
   updateFn?: (items: Set<V>, key: K, item: Partial<V>) => V
 }
+
+export interface StreammableStoreOptions<K, V> extends StoreOptions<K, V> {
+  streamFn?: (items: Set<V>, item: K) => AsyncIterable<V> | undefined
+}

--- a/packages/filecoin-api/test/events/aggregator.js
+++ b/packages/filecoin-api/test/events/aggregator.js
@@ -176,29 +176,32 @@ export const test = {
         bufferQueue: new FailingQueue(),
       })
     ),
-    'handles buffer queue messages repeated items as unique': async (
-      assert,
-      context
-    ) => {
-      const group = context.id.did()
-      const { buffers, blocks } = await getBuffers(1, group)
-  
-      // Store buffers
-      for (let i = 0; i < blocks.length; i++) {
-        const putBufferRes = await context.bufferStore.put({
-          buffer: buffers[i],
-          block: blocks[i].cid,
-        })
-        assert.ok(putBufferRes.ok)
-      }
- 
-      const bufferedPieces = await getBufferedPieces(
-        [blocks[0].cid, blocks[0].cid],
-        context.bufferStore
-      )
+  'handles buffer queue messages repeated items as unique': async (
+    assert,
+    context
+  ) => {
+    const group = context.id.did()
+    const { buffers, blocks } = await getBuffers(1, group)
 
-      assert.equal(bufferedPieces.ok?.bufferedPieces.length, buffers[0].pieces.length)
-    },
+    // Store buffers
+    for (let i = 0; i < blocks.length; i++) {
+      const putBufferRes = await context.bufferStore.put({
+        buffer: buffers[i],
+        block: blocks[i].cid,
+      })
+      assert.ok(putBufferRes.ok)
+    }
+
+    const bufferedPieces = await getBufferedPieces(
+      [blocks[0].cid, blocks[0].cid],
+      context.bufferStore
+    )
+
+    assert.equal(
+      bufferedPieces.ok?.bufferedPieces.length,
+      buffers[0].pieces.length
+    )
+  },
   'handles buffer queue messages successfully to requeue bigger buffer': async (
     assert,
     context
@@ -397,77 +400,82 @@ export const test = {
       message.minPieceInsertedAt
     )
   },
-  'handles buffer queue messages successfully to queue aggregate prepended with a buffer piece': async (
-    assert,
-    context
-  ) => {
-    const group = context.id.did()
-    const { buffers, blocks } = await getBuffers(2, group, {
-      length: 100,
-      size: 128,
-    })
-
-    const [cargo] = await randomCargo(1, 128)
-    /** @type {import('../../src/aggregator/api.js').BufferedPiece} */
-    const bufferedPiece = {
-      piece: cargo.link.link(),
-      policy: 0,
-      insertedAt: (new Date()).toISOString()
-    }
-
-    const totalPieces = buffers.reduce((acc, v) => {
-      acc += v.pieces.length
-      return acc
-    }, 0)
-
-    // Store buffers
-    for (let i = 0; i < blocks.length; i++) {
-      const putBufferRes = await context.bufferStore.put({
-        buffer: buffers[i],
-        block: blocks[i].cid,
+  'handles buffer queue messages successfully to queue aggregate prepended with a buffer piece':
+    async (assert, context) => {
+      const group = context.id.did()
+      const { buffers, blocks } = await getBuffers(2, group, {
+        length: 100,
+        size: 128,
       })
-      assert.ok(putBufferRes.ok)
-    }
 
-    // Handle messages
-    const handledMessageRes = await AggregatorEvents.handleBufferQueueMessage(
-      {
-        ...context,
-        config: {
-          minAggregateSize: 2 ** 19,
-          minUtilizationFactor: 10e5,
-          maxAggregateSize: 2 ** 35,
-          prependBufferedPieces: [bufferedPiece]
+      const [cargo] = await randomCargo(1, 128)
+      /** @type {import('../../src/aggregator/api.js').BufferedPiece} */
+      const bufferedPiece = {
+        piece: cargo.link.link(),
+        policy: 0,
+        insertedAt: new Date().toISOString(),
+      }
+
+      const totalPieces = buffers.reduce((acc, v) => {
+        acc += v.pieces.length
+        return acc
+      }, 0)
+
+      // Store buffers
+      for (let i = 0; i < blocks.length; i++) {
+        const putBufferRes = await context.bufferStore.put({
+          buffer: buffers[i],
+          block: blocks[i].cid,
+        })
+        assert.ok(putBufferRes.ok)
+      }
+
+      // Handle messages
+      const handledMessageRes = await AggregatorEvents.handleBufferQueueMessage(
+        {
+          ...context,
+          config: {
+            minAggregateSize: 2 ** 19,
+            minUtilizationFactor: 10e5,
+            maxAggregateSize: 2 ** 35,
+            prependBufferedPieces: [bufferedPiece],
+          },
         },
-      },
-      blocks.map((b) => ({
-        pieces: b.cid,
-        group,
-      }))
-    )
-    assert.ok(handledMessageRes.ok)
-    assert.equal(handledMessageRes.ok?.aggregatedPieces, totalPieces + 1)
+        blocks.map((b) => ({
+          pieces: b.cid,
+          group,
+        }))
+      )
+      assert.ok(handledMessageRes.ok)
+      assert.equal(handledMessageRes.ok?.aggregatedPieces, totalPieces + 1)
 
-    // Validate queue and store
-    await pWaitFor(
-      () =>
-        context.queuedMessages.get('aggregateOfferQueue')?.length === 1
-    )
+      // Validate queue and store
+      await pWaitFor(
+        () => context.queuedMessages.get('aggregateOfferQueue')?.length === 1
+      )
 
-    /** @type {AggregateOfferMessage} */
-    // @ts-expect-error cannot infer buffer message
-    const message = context.queuedMessages.get('aggregateOfferQueue')?.[0]
-    const bufferGet = await context.bufferStore.get(message.buffer)
-    assert.ok(bufferGet.ok)
-    assert.ok(bufferGet.ok?.block.equals(message.buffer))
-    assert.equal(bufferGet.ok?.buffer.group, group)
-    assert.ok(message.aggregate.equals(bufferGet.ok?.buffer.aggregate))
-    assert.equal(bufferGet.ok?.buffer.pieces.length, totalPieces + 1)
+      /** @type {AggregateOfferMessage} */
+      // @ts-expect-error cannot infer buffer message
+      const message = context.queuedMessages.get('aggregateOfferQueue')?.[0]
+      const bufferGet = await context.bufferStore.get(message.buffer)
+      assert.ok(bufferGet.ok)
+      assert.ok(bufferGet.ok?.block.equals(message.buffer))
+      assert.equal(bufferGet.ok?.buffer.group, group)
+      assert.ok(message.aggregate.equals(bufferGet.ok?.buffer.aggregate))
+      assert.equal(bufferGet.ok?.buffer.pieces.length, totalPieces + 1)
 
-    // prepended piece
-    assert.ok(bufferGet.ok?.buffer.pieces.find(p => p.piece.link().equals(bufferedPiece.piece.link())))
-    assert.ok(bufferGet.ok?.buffer.pieces[0].piece.link().equals(bufferedPiece.piece.link()))
-  },
+      // prepended piece
+      assert.ok(
+        bufferGet.ok?.buffer.pieces.find((p) =>
+          p.piece.link().equals(bufferedPiece.piece.link())
+        )
+      )
+      assert.ok(
+        bufferGet.ok?.buffer.pieces[0].piece
+          .link()
+          .equals(bufferedPiece.piece.link())
+      )
+    },
   'handles buffer queue messages successfully to queue aggregate and remaining buffer':
     async (assert, context) => {
       const group = context.id.did()

--- a/packages/filecoin-api/test/events/storefront.js
+++ b/packages/filecoin-api/test/events/storefront.js
@@ -39,13 +39,7 @@ export const test = {
     }
 
     // Store bytes on datastore
-    const asyncIterableMock = {
-      [Symbol.asyncIterator]: async function* () {
-        // Yield the Uint8Array asynchronously
-        yield cargo.bytes
-      },
-    }
-    await context.dataStore.put(asyncIterableMock)
+    await context.dataStore.put(cargo.bytes)
 
     // Handle message
     const handledMessageRes =

--- a/packages/filecoin-api/test/events/storefront.js
+++ b/packages/filecoin-api/test/events/storefront.js
@@ -9,6 +9,7 @@ import * as StorefrontEvents from '../../src/storefront/events.js'
 import {
   StoreOperationErrorName,
   UnexpectedStateErrorName,
+  BlobNotFoundErrorName
 } from '../../src/errors.js'
 
 import { randomCargo, randomAggregate } from '../utils.js'
@@ -37,6 +38,15 @@ export const test = {
       group: context.id.did(),
     }
 
+    // Store bytes on datastore
+    const asyncIterableMock = {
+      [Symbol.asyncIterator]: async function* () {
+        // Yield the Uint8Array asynchronously
+        yield cargo.bytes
+      },
+    }
+    await context.dataStore.put(asyncIterableMock)
+
     // Handle message
     const handledMessageRes =
       await StorefrontEvents.handleFilecoinSubmitMessage(context, message)
@@ -48,6 +58,23 @@ export const test = {
     })
     assert.ok(hasStoredPiece.ok)
     assert.equal(hasStoredPiece.ok?.status, 'submitted')
+  },
+  'handles filecoin submit messages with error if blob of content is not stored': async (assert, context) => {
+    // Generate piece for test
+    const [cargo] = await randomCargo(1, 128)
+
+    // Store piece into store
+    const message = {
+      piece: cargo.link.link(),
+      content: cargo.content.link(),
+      group: context.id.did(),
+    }
+
+    // Handle message
+    const handledMessageRes =
+      await StorefrontEvents.handleFilecoinSubmitMessage(context, message)
+    assert.ok(handledMessageRes.error)
+    assert.equal(handledMessageRes.error?.name, BlobNotFoundErrorName)
   },
   'handles filecoin submit messages deduping when stored': async (
     assert,
@@ -233,6 +260,47 @@ export const test = {
         context.service.filecoin?.submit?._params[0].nb.piece
       )
     )
+  },
+  'handles piece insert event to issue equivalency claims successfully': async (assert, context) => {
+    // Generate piece for test
+    const [cargo] = await randomCargo(1, 128)
+
+    // Store piece into store
+    const message = {
+      piece: cargo.link.link(),
+      content: cargo.content.link(),
+      group: context.id.did(),
+    }
+    /** @type {PieceRecord} */
+    const pieceRecord = {
+      ...message,
+      status: 'submitted',
+      insertedAt: new Date(Date.now() - 10).toISOString(),
+      updatedAt: new Date(Date.now() - 5).toISOString(),
+    }
+
+    // Handle message
+    const handledMessageRes = await StorefrontEvents.handlePieceInsertToEquivalencyClaim(
+      context,
+      pieceRecord
+    )
+    assert.ok(handledMessageRes.ok)
+    // Verify invocation
+    // @ts-expect-error not typed hooks
+    assert.equal(context.service.assert?.equals?.callCount, 1)
+    assert.ok(
+      message.content.equals(
+        // @ts-expect-error not typed hooks
+        context.service.assert?.equals?._params[0].nb.content
+      )
+    )
+    assert.ok(
+      message.piece.equals(
+        // @ts-expect-error not typed hooks
+        context.service.assert?.equals?._params[0].nb.equals
+      )
+    )
+
   },
   'handles piece status update event successfully': async (assert, context) => {
     // Generate piece for test

--- a/packages/filecoin-api/test/storefront.spec.js
+++ b/packages/filecoin-api/test/storefront.spec.js
@@ -87,7 +87,9 @@ describe('storefront', () => {
       define(name, async () => {
         const storefrontSigner = await Signer.generate()
         const aggregatorSigner = await Signer.generate()
+        const claimsSigner = await Signer.generate()
 
+        // TODO: Claims service
         const service = getMockService()
         const storefrontConnection = getConnection(
           storefrontSigner,
@@ -97,10 +99,11 @@ describe('storefront', () => {
           aggregatorSigner,
           service
         ).connection
+        const claimsConnection = getConnection(claimsSigner, service).connection
 
         // context
         const {
-          storefront: { pieceStore, taskStore, receiptStore },
+          storefront: { pieceStore, taskStore, receiptStore, dataStore },
         } = getStoreImplementations()
 
         await test(
@@ -115,6 +118,7 @@ describe('storefront', () => {
             pieceStore,
             receiptStore,
             taskStore,
+            dataStore,
             storefrontService: {
               connection: storefrontConnection,
               invocationConfig: {
@@ -129,6 +133,14 @@ describe('storefront', () => {
                 issuer: storefrontSigner,
                 with: storefrontSigner.did(),
                 audience: aggregatorSigner,
+              },
+            },
+            claimsService: {
+              connection: claimsConnection,
+              invocationConfig: {
+                issuer: storefrontSigner,
+                with: storefrontSigner.did(),
+                audience: claimsSigner,
               },
             },
             queuedMessages: new Map(),

--- a/packages/filecoin-api/test/types.ts
+++ b/packages/filecoin-api/test/types.ts
@@ -39,6 +39,7 @@ export interface StorefrontTestEventsContext
   extends StorefrontInterface.FilecoinSubmitMessageContext,
     StorefrontInterface.PieceOfferMessageContext,
     StorefrontInterface.StorefrontClientContext,
+    StorefrontInterface.ClaimsClientContext,
     StorefrontInterface.CronContext {
   id: Signer
   aggregatorId: Signer
@@ -47,5 +48,6 @@ export interface StorefrontTestEventsContext
     piece: Partial<import('../src/types.js').AggregatorService['piece']>
     aggregate: Partial<import('../src/types.js').DealerService['aggregate']>
     deal: Partial<import('../src/types.js').DealTrackerService['deal']>
+    assert: Partial<import('@web3-storage/content-claims/server/service/api').AssertService>
   }>
 }

--- a/packages/filecoin-api/test/utils.js
+++ b/packages/filecoin-api/test/utils.js
@@ -71,6 +71,7 @@ export async function randomCargo(length, size) {
       root: piece.root,
       content: car.cid,
       padding: piece.padding,
+      bytes: car.bytes,
     }
   })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7096,6 +7096,10 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
+  /fr32-sha2-256-trunc254-padded-binary-tree-multihash@3.3.0:
+    resolution: {integrity: sha512-O11VDxPmPvbQj5eac2BJXyieNacyd+RCMhwOzXQQM/NCI25x3c32YWB4/JwgOWPCpKnNXF6lpK/j0lj7GWOnYQ==}
+    dev: false
+
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,9 +257,15 @@ importers:
       '@web3-storage/capabilities':
         specifier: workspace:^
         version: link:../capabilities
+      '@web3-storage/content-claims':
+        specifier: ^4.0.2
+        version: 4.0.2
       '@web3-storage/data-segment':
         specifier: ^4.0.0
         version: 4.0.0
+      fr32-sha2-256-trunc254-padded-binary-tree-multihash:
+        specifier: ^3.3.0
+        version: 3.3.0
       p-map:
         specifier: ^6.0.0
         version: 6.0.0
@@ -4388,6 +4394,17 @@ packages:
       web-streams-polyfill: 3.2.1
     dev: false
 
+  /@web3-storage/content-claims@4.0.2:
+    resolution: {integrity: sha512-k6tIc7YjQtdKWi01r7+5stp2lo13ztwpIz+7NQYEbu5fZEsKKes5B4FKRqPWkZYO17+rPaihOY6sICT498c9EA==}
+    dependencies:
+      '@ucanto/client': 9.0.0
+      '@ucanto/interface': 9.0.0
+      '@ucanto/server': 9.0.1
+      '@ucanto/transport': 9.1.0
+      carstream: 1.1.1
+      multiformats: 12.1.3
+    dev: false
+
   /@web3-storage/data-segment@3.2.0:
     resolution: {integrity: sha512-SM6eNumXzrXiQE2/J59+eEgCRZNYPxKhRoHX2QvV3/scD4qgcf4g+paWBc3UriLEY1rCboygGoPsnqYJNyZyfA==}
     dependencies:
@@ -5232,6 +5249,14 @@ packages:
       ansicolors: 0.3.2
       redeyed: 2.1.1
     dev: true
+
+  /carstream@1.1.1:
+    resolution: {integrity: sha512-cgn3TqHo6SPsHBTfM5QgXngv6HtwgO1bKCHcdS35vBrweLcYrIG/+UboCbvnIGA0k8NtAYl/DvDdej/9pZGZxQ==}
+    dependencies:
+      '@ipld/dag-cbor': 9.0.6
+      multiformats: 12.1.3
+      uint8arraylist: 2.4.8
+    dev: false
 
   /cborg@4.0.5:
     resolution: {integrity: sha512-q8TAjprr8pn9Fp53rOIGp/UFDdFY6os2Nq62YogPSIzczJD9M6g2b6igxMkpCiZZKJ0kn/KzDLDvG+EqBIEeCg==}
@@ -9627,6 +9652,10 @@ packages:
     resolution: {integrity: sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
 
+  /multiformats@13.1.0:
+    resolution: {integrity: sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==}
+    dev: false
+
   /multimatch@5.0.0:
     resolution: {integrity: sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==}
     engines: {node: '>=10'}
@@ -12437,10 +12466,22 @@ packages:
     dev: true
     optional: true
 
+  /uint8arraylist@2.4.8:
+    resolution: {integrity: sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==}
+    dependencies:
+      uint8arrays: 5.0.3
+    dev: false
+
   /uint8arrays@4.0.6:
     resolution: {integrity: sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==}
     dependencies:
       multiformats: 12.1.3
+
+  /uint8arrays@5.0.3:
+    resolution: {integrity: sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==}
+    dependencies:
+      multiformats: 13.1.0
+    dev: false
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}


### PR DESCRIPTION
This PR hooks up possibility to compute Piece CID when submit message is received.

For extra context, today w3infra sets `skipFilecoinSubmitQueue` on `filecoin/offer` from users, resulting `filecoin/offer` in a noop that simply links receipts for effects of `filecoin/submit` and `filecoin/accept`. This is due to the API to not care about what was submit by client as it is calculated in bucket event anyway. However, we want to change this behaviour to have filecoin pipeline only triggered on `filecoin/offer`, putting it in the submit queue where validation will now happen.

We can summarise these changes in two units:
- `handleFilecoinSubmitMessage` now reads data from store, computes piece CID for the bytes and checks equality with provided Piece (i.e. bucket event code https://github.com/web3-storage/w3infra/blob/main/filecoin/index.js#L33 now lives in the handler
- `handlePieceInsertToEquivalencyClaim` now exposed in storefront events. This behaviour was [also triggered from bucket event](https://github.com/web3-storage/w3infra/blob/main/filecoin/index.js#L107) by the service. Now we make it a side effect of insertion to piece table, which happens on `handleFilecoinSubmitMessage`

Rollout plan:
- w3infra swaps `skipFilecoinSubmitQueue` to False when releasing with this. For the old bucket we invoke `filecoin/offer` from bucket event, given current client does not do it

Follow ups:
- [ ] `filecoin/offer` from service on old bucket event
- [ ] hook up finding where data is with datastore
- [ ] clean up `skipFilecoinSubmitQueue` option