### PR TITLE
fix: upload client should perform filecoin offer

### DIFF
--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -76,6 +76,7 @@
     "@ucanto/transport": "^9.1.0",
     "@web3-storage/capabilities": "workspace:^",
     "@web3-storage/data-segment": "^5.1.0",
+    "@web3-storage/filecoin-client": "workspace:^",
     "ipfs-utils": "^9.0.14",
     "multiformats": "^12.1.2",
     "p-retry": "^5.1.2",

--- a/packages/upload-client/src/index.js
+++ b/packages/upload-client/src/index.js
@@ -138,7 +138,7 @@ async function uploadBlockStream(conf, blocks, options = {}) {
             {
               issuer: conf.issuer,
               audience: conf.audience,
-              // Resource of storefront is the issuer did
+              // Resource of invocation is the issuer did for being self issued
               with: conf.issuer.did(),
               proofs: conf.proofs,
             },

--- a/packages/upload-client/src/index.js
+++ b/packages/upload-client/src/index.js
@@ -148,7 +148,10 @@ async function uploadBlockStream(conf, blocks, options = {}) {
           )
 
           if (result.out.error) {
-            throw new Error('failed to offer piece for aggregation into filecoin deal', { cause: result.out.error })
+            throw new Error(
+              'failed to offer piece for aggregation into filecoin deal',
+              { cause: result.out.error }
+            )
           }
 
           const { version, roots, size } = car

--- a/packages/upload-client/src/index.js
+++ b/packages/upload-client/src/index.js
@@ -148,7 +148,7 @@ async function uploadBlockStream(conf, blocks, options = {}) {
           )
 
           if (result.out.error) {
-            throw result.out.error
+            throw new Error('failed to offer piece for aggregation into filecoin deal', { cause: result.out.error })
           }
 
           const { version, roots, size } = car

--- a/packages/upload-client/src/index.js
+++ b/packages/upload-client/src/index.js
@@ -1,4 +1,5 @@
 import * as PieceHasher from '@web3-storage/data-segment/multihash'
+import { Storefront } from '@web3-storage/filecoin-client'
 import * as Link from 'multiformats/link'
 import * as raw from 'multiformats/codecs/raw'
 import * as Store from './store.js'
@@ -129,7 +130,27 @@ async function uploadBlockStream(conf, blocks, options = {}) {
           const multihashDigest = await hasher.digest(bytes)
           /** @type {import('@web3-storage/capabilities/types').PieceLink} */
           const piece = Link.create(raw.code, multihashDigest)
+
+          // Invoke store/add and write bytes to write target
           const cid = await Store.add(conf, bytes, options)
+          // Invoke filecoin/offer for data
+          const result = await Storefront.filecoinOffer(
+            {
+              issuer: conf.issuer,
+              audience: conf.audience,
+              // Resource of storefront is the issuer did
+              with: conf.issuer.did(),
+              proofs: conf.proofs,
+            },
+            cid,
+            piece,
+            options
+          )
+
+          if (result.out.error) {
+            throw result.out.error
+          }
+
           const { version, roots, size } = car
           controller.enqueue({ version, roots, size, cid, piece })
         },

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -44,6 +44,7 @@ import {
   UsageReportSuccess,
   UsageReportFailure,
 } from '@web3-storage/capabilities/types'
+import { StorefrontService } from '@web3-storage/filecoin-client/storefront'
 import { code as pieceHashCode } from '@web3-storage/data-segment/multihash'
 
 type Override<T, R> = Omit<T, keyof R> & R
@@ -93,7 +94,7 @@ export interface ProgressStatus extends XHRProgressStatus {
 
 export type ProgressFn = (status: ProgressStatus) => void
 
-export interface Service {
+export interface Service extends StorefrontService {
   store: {
     add: ServiceMethod<StoreAdd, StoreAddSuccess, Failure>
     get: ServiceMethod<StoreGet, StoreGetSuccess, StoreGetFailure>

--- a/packages/upload-client/test/helpers/filecoin.js
+++ b/packages/upload-client/test/helpers/filecoin.js
@@ -1,0 +1,32 @@
+import * as StorefrontCapabilities from '@web3-storage/capabilities/filecoin/storefront'
+import * as Server from '@ucanto/server'
+
+/**
+ * @param {Server.Signer<`did:${string}:${string}`, Server.API.SigAlg>} id
+ * @param {import('@web3-storage/data-segment').PieceLink} piece
+ * @param {Pick<{ content: Server.API.Link<unknown, number, number, 0 | 1>; piece: import('@web3-storage/data-segment').PieceLink; }, 'content' | 'piece'>} args
+ */
+export async function getFilecoinOfferResponse(id, piece, args) {
+  // Create effect for receipt with self signed queued operation
+  const submitfx = await StorefrontCapabilities.filecoinSubmit
+    .invoke({
+      issuer: id,
+      audience: id,
+      with: id.did(),
+      nb: args,
+      expiration: Infinity,
+    })
+    .delegate()
+
+  const acceptfx = await StorefrontCapabilities.filecoinAccept
+    .invoke({
+      issuer: id,
+      audience: id,
+      with: id.did(),
+      nb: args,
+      expiration: Infinity,
+    })
+    .delegate()
+
+  return Server.ok({ piece }).fork(submitfx.link()).join(acceptfx.link())
+}

--- a/packages/upload-client/test/helpers/mocks.js
+++ b/packages/upload-client/test/helpers/mocks.js
@@ -9,6 +9,7 @@ const notImplemented = () => {
  *   store: Partial<import('../../src/types.js').Service['store']>
  *   upload: Partial<import('../../src/types.js').Service['upload']>
  *   usage: Partial<import('../../src/types.js').Service['usage']>
+ *   filecoin: Partial<import('@web3-storage/filecoin-client/storefront').StorefrontService['filecoin']>
  * }>} impl
  */
 export function mockService(impl) {
@@ -27,6 +28,12 @@ export function mockService(impl) {
     },
     usage: {
       report: withCallCount(impl.usage?.report ?? notImplemented),
+    },
+    filecoin: {
+      offer: withCallCount(impl.filecoin?.offer ?? notImplemented),
+      submit: withCallCount(impl.filecoin?.submit ?? notImplemented),
+      accept: withCallCount(impl.filecoin?.accept ?? notImplemented),
+      info: withCallCount(impl.filecoin?.info ?? notImplemented),
     },
   }
 }

--- a/packages/upload-client/tsconfig.json
+++ b/packages/upload-client/tsconfig.json
@@ -6,7 +6,11 @@
   },
   "include": ["src", "scripts", "test", "package.json"],
   "exclude": ["**/node_modules/**"],
-  "references": [{ "path": "../access-client" }, { "path": "../capabilities" }],
+  "references": [
+    { "path": "../access-client" },
+    { "path": "../filecoin-client" },
+    { "path": "../capabilities" }
+  ],
   "typedocOptions": {
     "entryPoints": ["./src"]
   }

--- a/packages/w3up-client/test/helpers/filecoin.js
+++ b/packages/w3up-client/test/helpers/filecoin.js
@@ -1,0 +1,32 @@
+import * as StorefrontCapabilities from '@web3-storage/capabilities/filecoin/storefront'
+import * as Server from '@ucanto/server'
+
+/**
+ * @param {Server.Signer<`did:${string}:${string}`, Server.API.SigAlg>} id
+ * @param {import('@web3-storage/data-segment').PieceLink} piece
+ * @param {Pick<{ content: Server.API.Link<unknown, number, number, 0 | 1>; piece: import('@web3-storage/data-segment').PieceLink; }, 'content' | 'piece'>} args
+ */
+export async function getFilecoinOfferResponse(id, piece, args) {
+  // Create effect for receipt with self signed queued operation
+  const submitfx = await StorefrontCapabilities.filecoinSubmit
+    .invoke({
+      issuer: id,
+      audience: id,
+      with: id.did(),
+      nb: args,
+      expiration: Infinity,
+    })
+    .delegate()
+
+  const acceptfx = await StorefrontCapabilities.filecoinAccept
+    .invoke({
+      issuer: id,
+      audience: id,
+      with: id.did(),
+      nb: args,
+      expiration: Infinity,
+    })
+    .delegate()
+
+  return Server.ok({ piece }).fork(submitfx.link()).join(acceptfx.link())
+}

--- a/packages/w3up-client/tsconfig.json
+++ b/packages/w3up-client/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "../access-client" },
     { "path": "../capabilities" },
     { "path": "../upload-client" },
+    { "path": "../filecoin-client" },
     { "path": "../did-mailto" },
     { "path": "../upload-api" }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -470,6 +470,9 @@ importers:
       '@web3-storage/data-segment':
         specifier: ^5.1.0
         version: 5.1.0
+      '@web3-storage/filecoin-client':
+        specifier: workspace:^
+        version: link:../filecoin-client
       ipfs-utils:
         specifier: ^9.0.14
         version: 9.0.14


### PR DESCRIPTION
In context of https://github.com/w3s-project/project-tracking/issues/25 and https://github.com/web3-storage/w3infra/issues/344 we set the client to perform filecoin/offer already so that new users, as well as users that upgrade in the meantime can already perform this, in order to better prepare us to get rid of bucket event