### PR TITLE
fix!: drop filecoin storefront skip submit queue option

### DIFF
--- a/packages/filecoin-api/src/storefront/api.ts
+++ b/packages/filecoin-api/src/storefront/api.ts
@@ -34,13 +34,6 @@ export type DataStore = StreammableStore<UnknownLink, Uint8Array>
 export type TaskStore = Store<UnknownLink, Invocation>
 export type ReceiptStore = Store<UnknownLink, Receipt>
 
-export interface ServiceOptions {
-  /**
-   * Implementer MAY handle submission without user request.
-   */
-  skipFilecoinSubmitQueue?: boolean
-}
-
 export interface ServiceContext {
   /**
    * Service signer
@@ -74,10 +67,6 @@ export interface ServiceContext {
    * Deal tracker connection to find out available deals for an aggregate.
    */
   dealTrackerService: ServiceConfig<DealTrackerService>
-  /**
-   * Service options.
-   */
-  options?: ServiceOptions
 }
 
 export interface FilecoinSubmitMessageContext

--- a/packages/filecoin-api/src/storefront/service.js
+++ b/packages/filecoin-api/src/storefront/service.js
@@ -20,27 +20,24 @@ import {
 export const filecoinOffer = async ({ capability }, context) => {
   const { piece, content } = capability.nb
 
-  // Queue offer for filecoin submission
-  // We need to identify new client here...
-  if (!context.options?.skipFilecoinSubmitQueue) {
-    // dedupe
-    const hasRes = await context.pieceStore.has({ piece })
-    if (hasRes.error) {
-      return { error: new StoreOperationFailed(hasRes.error.message) }
-    }
+  // dedupe
+  const hasRes = await context.pieceStore.has({ piece })
+  if (hasRes.error) {
+    return { error: new StoreOperationFailed(hasRes.error.message) }
+  }
 
-    const group = context.id.did()
-    if (!hasRes.ok) {
-      // Queue the piece for validation etc.
-      const queueRes = await context.filecoinSubmitQueue.add({
-        piece,
-        content,
-        group,
-      })
-      if (queueRes.error) {
-        return {
-          error: new QueueOperationFailed(queueRes.error.message),
-        }
+  // Queue offer for filecoin submission
+  const group = context.id.did()
+  if (!hasRes.ok) {
+    // Queue the piece for validation etc.
+    const queueRes = await context.filecoinSubmitQueue.add({
+      piece,
+      content,
+      group,
+    })
+    if (queueRes.error) {
+      return {
+        error: new QueueOperationFailed(queueRes.error.message),
       }
     }
   }


### PR DESCRIPTION
This is not needed since https://github.com/web3-storage/w3up/pull/1332 got released and used in w3infra https://github.com/web3-storage/w3infra/pull/343 and has been deployed in production without issues for the last few weeks

BREAKING CHANGE: not possible to skip submit queue on storefront service anymore
