### PR TITLE
fix: capabilities should export blob caps

### DIFF
--- a/packages/capabilities/src/index.js
+++ b/packages/capabilities/src/index.js
@@ -45,6 +45,9 @@ export {
   UCAN,
   Plan,
   Usage,
+  Blob,
+  W3sBlob,
+  HTTP,
 }
 
 /** @type {import('./types.js').AbilitiesArray} */


### PR DESCRIPTION
Another small fix, just add exports on capabilities for blob caps