### PR TITLE
fix: access client should request blob namespace capabilities

### DIFF
--- a/packages/access-client/src/access.js
+++ b/packages/access-client/src/access.js
@@ -324,6 +324,7 @@ export const toCapabilities = (access) => {
  */
 export const spaceAccess = {
   'space/*': {},
+  'blob/*': {},
   'store/*': {},
   'upload/*': {},
   'access/*': {},


### PR DESCRIPTION
Client needs `blob/*` capabilities in order to invoke `blob/add`