### PR TITLE
fix: allocation interface rename invocation to cause

### DIFF
--- a/packages/upload-api/src/blob/allocate.js
+++ b/packages/upload-api/src/blob/allocate.js
@@ -35,7 +35,7 @@ export function blobAllocateProvider(context) {
       const allocationInsert = await context.allocationsStorage.insert({
         space,
         blob,
-        invocation: cause,
+        cause,
       })
       if (allocationInsert.error) {
         // if the insert failed with conflict then this item has already been

--- a/packages/upload-api/src/types/blob.ts
+++ b/packages/upload-api/src/types/blob.ts
@@ -38,16 +38,16 @@ export interface BlobModel {
 
 export interface BlobAddInput {
   space: DID
-  invocation: UnknownLink
+  cause: UnknownLink
   blob: BlobModel
 }
 
 export interface BlobAddOutput
-  extends Omit<BlobAddInput, 'space' | 'invocation'> {}
+  extends Omit<BlobAddInput, 'space' | 'cause'> {}
 
 export interface BlobGetOutput {
   blob: { digest: Uint8Array; size: number }
-  invocation: UnknownLink
+  cause: UnknownLink
 }
 
 export interface BlobsStorage {

--- a/packages/upload-api/test/storage/allocations-storage-tests.js
+++ b/packages/upload-api/test/storage/allocations-storage-tests.js
@@ -36,15 +36,14 @@ export const test = {
       },
       proofs: [proof],
     })
-    const invocation = (await blobAdd.delegate()).link()
-
+    const cause = (await blobAdd.delegate()).link()
     const allocationInsert = await allocationsStorage.insert({
       space: spaceDid,
       blob: {
         digest,
         size,
       },
-      invocation,
+      cause,
     })
 
     assert.ok(allocationInsert.ok)
@@ -72,15 +71,14 @@ export const test = {
       },
       proofs: [proof],
     })
-    const invocation = (await blobAdd.delegate()).link()
-
+    const cause = (await blobAdd.delegate()).link()
     const allocationInsert0 = await allocationsStorage.insert({
       space: spaceDid,
       blob: {
         digest,
         size,
       },
-      invocation,
+      cause,
     })
     assert.ok(allocationInsert0.ok)
 
@@ -90,7 +88,7 @@ export const test = {
         digest,
         size,
       },
-      invocation,
+      cause,
     })
     assert.ok(allocationInsert1.error)
     assert.equal(allocationInsert1.error?.name, RecordKeyConflictName)
@@ -121,15 +119,14 @@ export const test = {
       },
       proofs: [proof],
     })
-    const invocation = (await blobAdd.delegate()).link()
-
+    const cause = (await blobAdd.delegate()).link()
     const allocationInsert = await allocationsStorage.insert({
       space: spaceDid,
       blob: {
         digest,
         size,
       },
-      invocation,
+      cause,
     })
 
     assert.ok(allocationInsert.ok)
@@ -142,7 +139,7 @@ export const test = {
     assert.ok(
       equals(digest, allocationGet1.ok?.blob.digest || new Uint8Array())
     )
-    assert.ok(allocationGet1.ok?.invocation)
+    assert.ok(allocationGet1.ok?.cause)
   },
   'should verify allocations exist': async (assert, context) => {
     const { proof, spaceDid } = await registerSpace(alice, context)
@@ -170,15 +167,14 @@ export const test = {
       },
       proofs: [proof],
     })
-    const invocation = (await blobAdd.delegate()).link()
-
+    const cause = (await blobAdd.delegate()).link()
     const allocationInsert = await allocationsStorage.insert({
       space: spaceDid,
       blob: {
         digest,
         size,
       },
-      invocation,
+      cause,
     })
 
     assert.ok(allocationInsert.ok)
@@ -240,7 +236,7 @@ export const test = {
     const aliceAllocationInsert0 = await allocationsStorage.insert({
       space: aliceSpaceDid,
       blob: blob0,
-      invocation: aliceInvocation,
+      cause: aliceInvocation,
     })
     assert.ok(aliceAllocationInsert0.ok)
 
@@ -254,13 +250,13 @@ export const test = {
       },
       proofs: [bobProof],
     })
-    const invocation = (await bobBlobAdd.delegate()).link()
+    const cause = (await bobBlobAdd.delegate()).link()
 
     // Add bob allocations
     const bobAllocationInsert = await allocationsStorage.insert({
       space: bobSpaceDid,
       blob: blob1,
-      invocation,
+      cause,
     })
     assert.ok(bobAllocationInsert.ok)
 
@@ -291,7 +287,7 @@ export const test = {
     const aliceAllocationInsert1 = await allocationsStorage.insert({
       space: aliceSpaceDid,
       blob: blob1,
-      invocation: aliceInvocation1,
+      cause: aliceInvocation1,
     })
     assert.ok(aliceAllocationInsert1.ok)
 

--- a/packages/upload-api/test/storage/allocations-storage.js
+++ b/packages/upload-api/test/storage/allocations-storage.js
@@ -15,7 +15,7 @@ export class AllocationsStorage {
    * @param {Types.BlobAddInput} input
    * @returns {ReturnType<Types.AllocationsStorage['insert']>}
    */
-  async insert({ space, invocation, ...output }) {
+  async insert({ space, cause, ...output }) {
     if (
       this.items.some(
         (i) => i.space === space && equals(i.blob.digest, output.blob.digest)
@@ -27,7 +27,7 @@ export class AllocationsStorage {
     }
     this.items.unshift({
       space,
-      invocation,
+      cause,
       ...output,
       insertedAt: new Date().toISOString(),
     })


### PR DESCRIPTION
Per https://github.com/web3-storage/w3infra/pull/353#discussion_r1570092934 renaming this to cause so that it is transparent for the infra side what this is: i.e. can be invocation or receipt